### PR TITLE
Parsing published ISO STS XML document (ISO 8601-1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,5 @@ gem "rubocop", "~> 1.21"
 gem "rubocop-performance", "~> 1.19"
 
 gem "equivalent-xml", "~> 0.6"
+
+gem "xml-c14n"

--- a/lib/sts/niso_sts/custom_meta_group.rb
+++ b/lib/sts/niso_sts/custom_meta_group.rb
@@ -11,6 +11,7 @@ module Sts
 
       xml do
         root "custom-meta-group"
+
         map_element "custom-meta", to: :custom_meta
       end
     end

--- a/lib/sts/niso_sts/ext_link.rb
+++ b/lib/sts/niso_sts/ext_link.rb
@@ -6,6 +6,7 @@ module Sts
   module NisoSts
     class ExtLink < Sts::Mapper
       attribute :ext_link_type, Shale::Type::String
+      attribute :href, Shale::Type::String
       attribute :content, Shale::Type::String
 
       xml do
@@ -14,6 +15,9 @@ module Sts
         map_content to: :content
 
         map_attribute "ext-link-type", to: :ext_link_type
+        map_attribute "href", to: :href,
+                              namespace: "http://www.w3.org/1999/xlink",
+                              prefix: "xlink"
       end
     end
   end

--- a/lib/sts/niso_sts/fn.rb
+++ b/lib/sts/niso_sts/fn.rb
@@ -2,13 +2,14 @@
 
 require_relative "../mapper"
 
+require_relative "label"
 require_relative "paragraph"
 
 module Sts
   module NisoSts
     class Fn < Sts::Mapper
       attribute :id, Shale::Type::String
-      attribute :label, Shale::Type::String
+      attribute :label, Label
       attribute :paragraph, Paragraph
 
       xml do

--- a/lib/sts/niso_sts/label.rb
+++ b/lib/sts/niso_sts/label.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "../mapper"
+
+require_relative "../tbx_iso_tml/sup"
+
+module Sts
+  module NisoSts
+    class Label < Sts::Mapper
+      attribute :content, Shale::Type::String
+      attribute :sup, Sts::TbxIsoTml::Sup
+
+      xml do
+        root "label"
+
+        map_content to: :content
+        map_element "sup", to: :sup
+      end
+    end
+  end
+end

--- a/lib/sts/niso_sts/list_item.rb
+++ b/lib/sts/niso_sts/list_item.rb
@@ -2,6 +2,7 @@
 
 require_relative "../mapper"
 require_relative "list"
+require_relative "non_normative_example"
 
 module Sts
   module NisoSts
@@ -10,15 +11,17 @@ module Sts
 
     class ListItem < Sts::Mapper
       attribute :label, Shale::Type::String
-      attribute :p, Sts::NisoSts::Paragraph
       attribute :list, List
+      attribute :non_normative_example, NonNormativeExample
+      attribute :p, Sts::NisoSts::Paragraph
 
       xml do
         root "list-item"
 
         map_element :label, to: :label
-        map_element :p, to: :p
         map_element :list, to: :list
+        map_element "non-normative-example", to: :non_normative_example
+        map_element :p, to: :p
       end
     end
   end

--- a/lib/sts/niso_sts/meta_date.rb
+++ b/lib/sts/niso_sts/meta_date.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../mapper"
+
+module Sts
+  module NisoSts
+    class MetaDate < Sts::Mapper
+      attribute :content, Shale::Type::String
+      attribute :type, Shale::Type::String
+
+      xml do
+        root "meta-date"
+
+        map_content to: :content
+
+        map_attribute :type, to: :type
+      end
+    end
+  end
+end

--- a/lib/sts/niso_sts/metadata_iso.rb
+++ b/lib/sts/niso_sts/metadata_iso.rb
@@ -1,40 +1,56 @@
 # frozen_string_literal: true
 
 require_relative "../mapper"
-require_relative "title_wrap"
+
+require_relative "custom_meta_group"
 require_relative "document_identification"
+require_relative "meta_date"
+require_relative "page_count"
+require_relative "permissions"
 require_relative "standard_identification"
 require_relative "standard_ref"
-require_relative "page_count"
+require_relative "std_cross_reference"
+require_relative "title_wrap"
 
 module Sts
   module NisoSts
     class MetadataIso < Sts::Mapper
-      attribute :title_wrap, TitleWrap
+      attribute :comm_ref, Shale::Type::String
       attribute :content_language, Shale::Type::String
-      attribute :std_ident, StandardIdentification
+      attribute :custom_meta_group, CustomMetaGroup
       attribute :doc_ident, DocumentIdentification
-      attribute :std_ref, StandardRef
       attribute :doc_ref, Shale::Type::String
+      attribute :ics, Shale::Type::String
+      attribute :meta_date, MetaDate
+      attribute :page_count, PageCount
+      attribute :permissions, Permissions
       attribute :pub_date, Shale::Type::String
       attribute :release_date, Shale::Type::String
-      attribute :comm_ref, Shale::Type::String
       attribute :secretariat, Shale::Type::String
-      attribute :page_count, PageCount
+      attribute :std_ident, StandardIdentification
+      attribute :std_ref, StandardRef
+      attribute :std_xref, StdCrossReference
+      attribute :title_wrap, TitleWrap
 
       xml do
         root "iso-meta"
-        map_element "title-wrap", to: :title_wrap
+
+        map_element "comm-ref", to: :comm_ref
         map_element "content-language", to: :content_language
-        map_element "std-ident", to: :std_ident
+        map_element "custom-meta-group", to: :custom_meta_group
         map_element "doc-ident", to: :doc_ident
-        map_element "std-ref", to: :std_ref
         map_element "doc-ref", to: :doc_ref
+        map_element "ics", to: :ics
+        map_element "meta-date", to: :meta_date
+        map_element "page-count", to: :page_count
+        map_element "permissions", to: :permissions
         map_element "pub-date", to: :pub_date
         map_element "release-date", to: :release_date
-        map_element "comm-ref", to: :comm_ref
         map_element "secretariat", to: :secretariat
-        map_element "page-count", to: :page_count
+        map_element "std-ident", to: :std_ident
+        map_element "std-ref", to: :std_ref
+        map_element "std-xref", to: :std_xref
+        map_element "title-wrap", to: :title_wrap
       end
     end
   end

--- a/lib/sts/niso_sts/metadata_std.rb
+++ b/lib/sts/niso_sts/metadata_std.rb
@@ -35,7 +35,9 @@ module Sts
 
       xml do
         root "std-meta"
+
         map_attribute "id", to: :id
+
         map_element "title-wrap", to: :title_wrap
         map_element "content-language", to: :content_language
         map_element "std-ident", to: :std_ident

--- a/lib/sts/niso_sts/mixed_citation.rb
+++ b/lib/sts/niso_sts/mixed_citation.rb
@@ -10,6 +10,8 @@ module Sts
     class MixedCitation < Sts::Mapper
       attribute :content, Shale::Type::String
       attribute :bold, Shale::Type::String
+      attribute :italic, Shale::Type::String
+      attribute :publication_type, Shale::Type::String
       attribute :std, ReferenceStandard
       attribute :ext_link, ExtLink
 
@@ -18,7 +20,10 @@ module Sts
 
         map_content to: :content
 
+        map_attribute "publication-type", to: :publication_type
+
         map_element "bold", to: :bold
+        map_element "italic", to: :italic
         map_element "std", to: :std
         map_element "ext-link", to: :ext_link
       end

--- a/lib/sts/niso_sts/non_normative_example.rb
+++ b/lib/sts/niso_sts/non_normative_example.rb
@@ -6,6 +6,8 @@ require_relative "paragraph"
 
 module Sts
   module NisoSts
+    class Paragraph < Sts::Mapper; end
+
     class NonNormativeExample < Sts::Mapper
       attribute :id, Shale::Type::String
       attribute :p, Paragraph
@@ -13,6 +15,7 @@ module Sts
 
       xml do
         root "non-normative-example"
+
         map_attribute "id", to: :id
         map_element "p", to: :p
         map_element "label", to: :label

--- a/lib/sts/niso_sts/paragraph.rb
+++ b/lib/sts/niso_sts/paragraph.rb
@@ -9,17 +9,21 @@ require_relative "def_list"
 require_relative "non_normative_note"
 require_relative "non_normative_example"
 require_relative "reference_standard"
+require_relative "ext_link"
+require_relative "../tbx_iso_tml/entailed_term"
 require_relative "../tbx_iso_tml/xref"
 
 module Sts
   module NisoSts
     class NonNormativeNote < Sts::Mapper; end
+    class ReferenceStandard < Sts::Mapper; end
 
     class Paragraph < Sts::Mapper
       attribute :id, Shale::Type::String
       attribute :text, Shale::Type::String
       attribute :italic, Shale::Type::String
       attribute :bold, Shale::Type::String
+      attribute :uri, Shale::Type::String
       attribute :list, Sts::NisoSts::List
       attribute :def_list, DefList
       attribute :non_normative_note, NonNormativeNote
@@ -28,6 +32,8 @@ module Sts
       attribute :disp_formula, Sts::NisoSts::DisplayFormula, collection: true
       attribute :xref, TbxIsoTml::Xref
       attribute :std, ReferenceStandard
+      attribute :ext_link, ExtLink
+      attribute :entailed_term, Sts::TbxIsoTml::EntailedTerm
 
       xml do
         root "p"
@@ -42,6 +48,11 @@ module Sts
         map_element "non-normative-example", to: :non_normative_example
         map_element "inline-formula", to: :inline_formula
         map_element "disp-formula", to: :disp_formula
+        map_element "ext-link", to: :ext_link
+        map_element "entailedTerm", to: :entailed_term,
+                                    namespace: "urn:iso:std:iso:30042:ed-1",
+                                    prefix: "tbx"
+        map_element "uri", to: :uri
         map_element "std", to: :std, namespace: nil, prefix: nil
         map_element "xref", to: :xref, namespace: nil, prefix: nil
       end

--- a/lib/sts/niso_sts/reference_standard.rb
+++ b/lib/sts/niso_sts/reference_standard.rb
@@ -3,6 +3,7 @@
 require_relative "../mapper"
 require_relative "standard_ref"
 require_relative "std_id_group"
+require_relative "fn"
 require_relative "../tbx_iso_tml/xref"
 
 module Sts
@@ -13,6 +14,7 @@ module Sts
       attribute :content, Shale::Type::String
       attribute :std_ref, StandardRef
       attribute :title, Shale::Type::String
+      attribute :fn, Fn, collection: true
       attribute :std_id_group, StdIdGroup, collection: true
       attribute :xref, Sts::TbxIsoTml::Xref, collection: true
 
@@ -21,7 +23,9 @@ module Sts
 
         map_attribute "type", to: :type
         map_attribute "std-id", to: :std_id
+
         map_element "std-ref", to: :std_ref, namespace: nil, prefix: nil
+        map_element "fn", to: :fn, namespace: nil, prefix: nil
         map_element "title", to: :title, namespace: nil, prefix: nil
         map_element "std-id-group", to: :std_id_group,
                                     namespace: nil,

--- a/lib/sts/niso_sts/section.rb
+++ b/lib/sts/niso_sts/section.rb
@@ -10,6 +10,7 @@ require_relative "non_normative_note"
 require_relative "non_normative_example"
 require_relative "figure"
 require_relative "title"
+require_relative "section_array"
 
 require_relative "../tbx_iso_tml/table_wrap"
 
@@ -23,6 +24,7 @@ module Sts
       attribute :label, Shale::Type::String
       attribute :title, Title
       attribute :type, Shale::Type::String
+      attribute :array, SectionArray
       attribute :paragraphs, Paragraph, collection: true
       attribute :list, List, collection: true
       attribute :term_sec, TermSection, collection: true
@@ -51,6 +53,7 @@ module Sts
         map_element "figure", to: :figures
         map_element "fig", to: :fig
         map_element "ref-list", to: :ref_list
+        map_element "array", to: :array
         map_element "table-wrap", to: :table_wrap
         map_element "non-normative-note", to: :non_normative_note
         map_element "non-normative-example", to: :non_normative_example

--- a/lib/sts/niso_sts/section_array.rb
+++ b/lib/sts/niso_sts/section_array.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "../mapper"
+
+require_relative "../tbx_iso_tml/table"
+
+module Sts
+  module NisoSts
+    class SectionArray < Sts::Mapper
+      attribute :id, Shale::Type::String
+      attribute :table, Sts::TbxIsoTml::Table
+
+      xml do
+        root "array"
+
+        map_attribute "id", to: :id
+        map_element "table", to: :table
+      end
+    end
+  end
+end

--- a/lib/sts/niso_sts/std_cross_reference.rb
+++ b/lib/sts/niso_sts/std_cross_reference.rb
@@ -9,7 +9,8 @@ module Sts
       attribute :std_ref, StandardRef, collection: true
 
       xml do
-        root "iso-meta"
+        root "std-xref"
+
         map_attribute "type", to: :type
         map_element "std-ref", to: :std_ref
       end

--- a/lib/sts/tbx_iso_tml/table.rb
+++ b/lib/sts/tbx_iso_tml/table.rb
@@ -15,6 +15,7 @@ module Sts
       attribute :border, Shale::Type::String
       attribute :rules, Shale::Type::String
       attribute :frame, Shale::Type::String
+      attribute :width, Shale::Type::String
 
       xml do
         root "table"
@@ -22,6 +23,7 @@ module Sts
         map_attribute "border", to: :border
         map_attribute "rules", to: :rules
         map_attribute "frame", to: :frame
+        map_attribute "width", to: :width
 
         map_element "col", to: :col
         map_element "thead", to: :thead

--- a/lib/sts/tbx_iso_tml/table_wrap.rb
+++ b/lib/sts/tbx_iso_tml/table_wrap.rb
@@ -10,6 +10,7 @@ module Sts
     class TableWrap < Sts::Mapper
       attribute :id, Shale::Type::String
       attribute :orientation, Shale::Type::String
+      attribute :position, Shale::Type::String
       attribute :label, Shale::Type::String
       attribute :table, Sts::TbxIsoTml::Table, collection: true
       attribute :table_wrap_foot, Sts::TbxIsoTml::TableWrapFoot
@@ -23,6 +24,8 @@ module Sts
 
         map_attribute "id", to: :id
         map_attribute "orientation", to: :orientation
+        map_attribute "position", to: :position
+
         map_element "label", to: :label
         map_element "caption", to: :caption
         map_element "table", to: :table

--- a/lib/sts/tbx_iso_tml/td.rb
+++ b/lib/sts/tbx_iso_tml/td.rb
@@ -10,12 +10,15 @@ require_relative "../niso_sts/inline_formula"
 require_relative "../niso_sts/non_normative_note"
 require_relative "../niso_sts/graphic"
 require_relative "../niso_sts/def_list"
+require_relative "../niso_sts/paragraph"
 
 module Sts
   module TbxIsoTml
     class Td < Sts::Mapper
       attribute :content, Shale::Type::String
       attribute :align, Shale::Type::String
+      attribute :scope, Shale::Type::String
+      attribute :style, Shale::Type::String
       attribute :bold, Bold
       attribute :italic, Italic
       attribute :content_type, Shale::Type::String
@@ -31,6 +34,7 @@ module Sts
       attribute :std, Sts::NisoSts::ReferenceStandard
       attribute :graphic, Sts::NisoSts::Graphic
       attribute :def_list, Sts::NisoSts::DefList
+      attribute :paragraph, Sts::NisoSts::Paragraph
 
       xml do
         root "tr"
@@ -38,6 +42,8 @@ module Sts
         map_content to: :content
 
         map_attribute "align", to: :align
+        map_attribute "scope", to: :scope
+        map_attribute "style", to: :style
         map_attribute "content-type", to: :content_type
         map_attribute "char", to: :char
         map_attribute "charoff", to: :charoff
@@ -54,6 +60,7 @@ module Sts
         map_element "non-normative-note", to: :non_normative_note
         map_element "graphic", to: :graphic
         map_element "def-list", to: :def_list
+        map_element "p", to: :paragraph
       end
     end
   end

--- a/lib/sts/tbx_iso_tml/th.rb
+++ b/lib/sts/tbx_iso_tml/th.rb
@@ -14,6 +14,8 @@ module Sts
       attribute :content, Shale::Type::String
       attribute :colspan, Shale::Type::String
       attribute :align, Shale::Type::String
+      attribute :scope, Shale::Type::String
+      attribute :style, Shale::Type::String
       attribute :rowspan, Shale::Type::String
       attribute :break, Shale::Type::String
       attribute :content_type, Shale::Type::String
@@ -32,6 +34,8 @@ module Sts
         map_content to: :content
         map_attribute "colspan", to: :colspan
         map_attribute "align", to: :align
+        map_attribute "scope", to: :scope
+        map_attribute "style", to: :style
         map_attribute "rowspan", to: :rowspan
         map_attribute "content-type", to: :content_type
         map_attribute "char", to: :char

--- a/sts.gemspec
+++ b/sts.gemspec
@@ -32,9 +32,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri"
   spec.add_dependency "shale"
   # spec.add_dependency "thor"
-
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "xml-c14n"
 end


### PR DESCRIPTION
Fully parsing published ISO STS XML document (ISO 8601-1) -> https://github.com/metanorma/iso-8601-1/blob/dfdff8e439ae77b5d1e7a3f9c7bc51c9a61d92f3/submission/iso-8601-1-nisosts/C070907e.xml

closes #5 