### PR TITLE
fix: failing specs due to lutaml-model gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "equivalent-xml"
-gem "lutaml-model", github: "lutaml/lutaml-model", branch: "main"
 gem "pry"
 gem "rake"
 gem "rspec"


### PR DESCRIPTION
The following line in the dependent gems CI was not working because we already have the `lutaml-model` added as a dependency. So, I removed it for now to ensure the workflow runs as expected.

`bundle add lutaml-model --path ..`

needed for #19 