### PR TITLE
revert: lutaml-model version to 0.6

### DIFF
--- a/sts.gemspec
+++ b/sts.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bigdecimal"
-  spec.add_dependency "lutaml-model", "~> 0.7"
+  # TODO: update to 0.7 once that is released
+  spec.add_dependency "lutaml-model", "~> 0.6"
   spec.add_dependency "nokogiri"
 
   # spec.add_dependency "thor"


### PR DESCRIPTION
The specs are failing because version `0.7` of `lutaml-model` was yanked. I've temporarily downgraded it and will update once 0.7 is released.