### PR TITLE
fix: add collection: true to mixed content attributes

### DIFF
--- a/lib/sts/iso_sts/annex_type.rb
+++ b/lib/sts/iso_sts/annex_type.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class AnnexType < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
 

--- a/lib/sts/iso_sts/bold.rb
+++ b/lib/sts/iso_sts/bold.rb
@@ -5,7 +5,7 @@ module Sts
     class Bold < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :specific_use, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :sub, ::Sts::NisoSts::Sub

--- a/lib/sts/iso_sts/comm_ref.rb
+++ b/lib/sts/iso_sts/comm_ref.rb
@@ -3,8 +3,7 @@
 module Sts
   module IsoSts
     class CommRef < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "comm-ref"
         mixed_content

--- a/lib/sts/iso_sts/copyright_holder.rb
+++ b/lib/sts/iso_sts/copyright_holder.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class CopyrightHolder < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :sub, ::Sts::NisoSts::Sub
       attribute :sup, ::Sts::NisoSts::Sup
 

--- a/lib/sts/iso_sts/copyright_statement.rb
+++ b/lib/sts/iso_sts/copyright_statement.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class CopyrightStatement < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :ext_link, ::Sts::NisoSts::ExtLink

--- a/lib/sts/iso_sts/doc_ref.rb
+++ b/lib/sts/iso_sts/doc_ref.rb
@@ -3,8 +3,7 @@
 module Sts
   module IsoSts
     class DocRef < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "doc-ref"
         mixed_content

--- a/lib/sts/iso_sts/edition.rb
+++ b/lib/sts/iso_sts/edition.rb
@@ -3,8 +3,7 @@
 module Sts
   module IsoSts
     class Edition < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "edition"
         mixed_content

--- a/lib/sts/iso_sts/italic.rb
+++ b/lib/sts/iso_sts/italic.rb
@@ -5,7 +5,7 @@ module Sts
     class Italic < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :specific_use, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :sub, ::Sts::NisoSts::Sub

--- a/lib/sts/iso_sts/label.rb
+++ b/lib/sts/iso_sts/label.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class Label < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :sub, ::Sts::NisoSts::Sub

--- a/lib/sts/iso_sts/language.rb
+++ b/lib/sts/iso_sts/language.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class Language < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :lang, :string
       attribute :specific_use, :string
 

--- a/lib/sts/iso_sts/mathml2/math.rb
+++ b/lib/sts/iso_sts/mathml2/math.rb
@@ -8,8 +8,7 @@ module Sts
       class Math < Lutaml::Model::Serializable
         attribute :id, :string
         attribute :display, :string
-        attribute :content, :string
-
+        attribute :content, :string, collection: true
         xml do
           namespace ::Sts::Namespaces::MathmlNamespace
           element "math"

--- a/lib/sts/iso_sts/mixed_citation.rb
+++ b/lib/sts/iso_sts/mixed_citation.rb
@@ -9,7 +9,7 @@ module Sts
       attribute :publication_format, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :sub, ::Sts::NisoSts::Sub

--- a/lib/sts/iso_sts/paragraph.rb
+++ b/lib/sts/iso_sts/paragraph.rb
@@ -9,7 +9,7 @@ module Sts
       attribute :xml_lang, :string
       attribute :originator, :string
       attribute :style_type, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :xref, ::Sts::TbxIsoTml::Xref

--- a/lib/sts/iso_sts/preformat.rb
+++ b/lib/sts/iso_sts/preformat.rb
@@ -10,7 +10,7 @@ module Sts
       attribute :xml_lang, :string
       attribute :preformat_type, :string
       attribute :originator, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :ext_link, ::Sts::NisoSts::ExtLink

--- a/lib/sts/iso_sts/release_date.rb
+++ b/lib/sts/iso_sts/release_date.rb
@@ -3,8 +3,7 @@
 module Sts
   module IsoSts
     class ReleaseDate < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "release-date"
         mixed_content

--- a/lib/sts/iso_sts/secretariat.rb
+++ b/lib/sts/iso_sts/secretariat.rb
@@ -3,8 +3,7 @@
 module Sts
   module IsoSts
     class Secretariat < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "secretariat"
         mixed_content

--- a/lib/sts/iso_sts/std.rb
+++ b/lib/sts/iso_sts/std.rb
@@ -15,8 +15,7 @@ module Sts
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :named_content, ::Sts::NisoSts::NamedContent
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "std"
         mixed_content

--- a/lib/sts/iso_sts/std_ref.rb
+++ b/lib/sts/iso_sts/std_ref.rb
@@ -12,8 +12,7 @@ module Sts
       attribute :suppl_type, ::Sts::NisoSts::SupplType
       attribute :suppl_number, ::Sts::NisoSts::SupplNumber
       attribute :year, ::Sts::NisoSts::Year
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "std-ref"
         mixed_content

--- a/lib/sts/iso_sts/styled_content.rb
+++ b/lib/sts/iso_sts/styled_content.rb
@@ -8,7 +8,7 @@ module Sts
       attribute :alt, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold, collection: true
       attribute :italic, ::Sts::IsoSts::Italic, collection: true
       attribute :sub, ::Sts::NisoSts::Sub

--- a/lib/sts/iso_sts/sub.rb
+++ b/lib/sts/iso_sts/sub.rb
@@ -3,8 +3,7 @@
 module Sts
   module IsoSts
     class Sub < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sub"
         mixed_content

--- a/lib/sts/iso_sts/sup.rb
+++ b/lib/sts/iso_sts/sup.rb
@@ -3,8 +3,7 @@
 module Sts
   module IsoSts
     class Sup < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sup"
         mixed_content

--- a/lib/sts/iso_sts/td.rb
+++ b/lib/sts/iso_sts/td.rb
@@ -16,7 +16,7 @@ module Sts
       attribute :char, :string
       attribute :charoff, :string
       attribute :valign, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :paragraph, ::Sts::IsoSts::Paragraph, collection: true
       attribute :fig, ::Sts::IsoSts::Fig
       attribute :graphic, ::Sts::IsoSts::Graphic

--- a/lib/sts/iso_sts/term.rb
+++ b/lib/sts/iso_sts/term.rb
@@ -7,7 +7,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :sub, ::Sts::NisoSts::Sub

--- a/lib/sts/iso_sts/th.rb
+++ b/lib/sts/iso_sts/th.rb
@@ -16,7 +16,7 @@ module Sts
       attribute :char, :string
       attribute :charoff, :string
       attribute :valign, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :paragraph, ::Sts::IsoSts::Paragraph, collection: true
       attribute :fig, ::Sts::IsoSts::Fig
       attribute :graphic, ::Sts::IsoSts::Graphic

--- a/lib/sts/iso_sts/title.rb
+++ b/lib/sts/iso_sts/title.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class Title < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :sub, ::Sts::NisoSts::Sub

--- a/lib/sts/iso_sts/title_compl.rb
+++ b/lib/sts/iso_sts/title_compl.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class TitleCompl < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :xref, ::Sts::TbxIsoTml::Xref

--- a/lib/sts/iso_sts/title_full.rb
+++ b/lib/sts/iso_sts/title_full.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class TitleFull < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :xref, ::Sts::TbxIsoTml::Xref

--- a/lib/sts/iso_sts/title_intro.rb
+++ b/lib/sts/iso_sts/title_intro.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class TitleIntro < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :xref, ::Sts::TbxIsoTml::Xref

--- a/lib/sts/iso_sts/title_main.rb
+++ b/lib/sts/iso_sts/title_main.rb
@@ -3,7 +3,7 @@
 module Sts
   module IsoSts
     class TitleMain < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :xref, ::Sts::TbxIsoTml::Xref

--- a/lib/sts/niso_sts/access_date.rb
+++ b/lib/sts/niso_sts/access_date.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class AccessDate < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/accrediting_organization.rb
+++ b/lib/sts/niso_sts/accrediting_organization.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class AccreditingOrganization < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "accrediting-organization"
         mixed_content

--- a/lib/sts/niso_sts/addr_line.rb
+++ b/lib/sts/niso_sts/addr_line.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class AddrLine < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/aff.rb
+++ b/lib/sts/niso_sts/aff.rb
@@ -4,7 +4,7 @@ module Sts
   module NisoSts
     class Aff < Lutaml::Model::Serializable
       attribute :id, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string

--- a/lib/sts/niso_sts/ali/license_ref.rb
+++ b/lib/sts/niso_sts/ali/license_ref.rb
@@ -4,7 +4,7 @@ module Sts
   module NisoSts
     module Ali
       class LicenseRef < Lutaml::Model::Serializable
-        attribute :content, :string
+        attribute :content, :string, collection: true
         attribute :content_type, :string
         attribute :id, :string
         attribute :specific_use, :string

--- a/lib/sts/niso_sts/alt_text.rb
+++ b/lib/sts/niso_sts/alt_text.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class AltText < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "alt-text"
         mixed_content

--- a/lib/sts/niso_sts/alt_title.rb
+++ b/lib/sts/niso_sts/alt_title.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class AltTitle < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "alt-title"
         mixed_content

--- a/lib/sts/niso_sts/alternatives.rb
+++ b/lib/sts/niso_sts/alternatives.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Alternatives < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "alternatives"
         mixed_content

--- a/lib/sts/niso_sts/annotation.rb
+++ b/lib/sts/niso_sts/annotation.rb
@@ -8,8 +8,7 @@ module Sts
       attribute :xml_lang, :string
       attribute :specific_use, :string
       attribute :symbol, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "annotation"
         mixed_content

--- a/lib/sts/niso_sts/article_title.rb
+++ b/lib/sts/niso_sts/article_title.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class ArticleTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/attrib.rb
+++ b/lib/sts/niso_sts/attrib.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Attrib < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "attrib"
         mixed_content

--- a/lib/sts/niso_sts/attribution.rb
+++ b/lib/sts/niso_sts/attribution.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Attribution < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "attribution"
         mixed_content

--- a/lib/sts/niso_sts/author_comment.rb
+++ b/lib/sts/niso_sts/author_comment.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "author-comment"
         mixed_content

--- a/lib/sts/niso_sts/authorization.rb
+++ b/lib/sts/niso_sts/authorization.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Authorization < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "authorization"
         mixed_content

--- a/lib/sts/niso_sts/award_id.rb
+++ b/lib/sts/niso_sts/award_id.rb
@@ -5,8 +5,7 @@ module Sts
     class AwardId < Lutaml::Model::Serializable
       attribute :award_id_type, :string
       attribute :rid, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "award-id"
         mixed_content

--- a/lib/sts/niso_sts/bio.rb
+++ b/lib/sts/niso_sts/bio.rb
@@ -4,7 +4,7 @@ module Sts
   module NisoSts
     class Bio < Lutaml::Model::Serializable
       attribute :id, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
       attribute :paragraph, ::Sts::NisoSts::Paragraph, collection: true

--- a/lib/sts/niso_sts/chapter_title.rb
+++ b/lib/sts/niso_sts/chapter_title.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class ChapterTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/chem_struct.rb
+++ b/lib/sts/niso_sts/chem_struct.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ChemStruct < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "chem-struct"
         mixed_content

--- a/lib/sts/niso_sts/city.rb
+++ b/lib/sts/niso_sts/city.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class City < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/collab.rb
+++ b/lib/sts/niso_sts/collab.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Collab < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string

--- a/lib/sts/niso_sts/comment.rb
+++ b/lib/sts/niso_sts/comment.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Comment < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "comment"
         mixed_content

--- a/lib/sts/niso_sts/compound_kwd_part.rb
+++ b/lib/sts/niso_sts/compound_kwd_part.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :id, :string
       attribute :kwd_part_type, :string
       attribute :value, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "compound-kwd-part"
         mixed_content

--- a/lib/sts/niso_sts/conf_acronym.rb
+++ b/lib/sts/niso_sts/conf_acronym.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ConfAcronym < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "conf-acronym"
         mixed_content

--- a/lib/sts/niso_sts/conf_date.rb
+++ b/lib/sts/niso_sts/conf_date.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class ConfDate < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :specific_use, :string
 

--- a/lib/sts/niso_sts/conf_loc.rb
+++ b/lib/sts/niso_sts/conf_loc.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ConfLoc < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "conf-loc"
         mixed_content

--- a/lib/sts/niso_sts/conf_name.rb
+++ b/lib/sts/niso_sts/conf_name.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ConfName < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "conf-name"
         mixed_content

--- a/lib/sts/niso_sts/conf_num.rb
+++ b/lib/sts/niso_sts/conf_num.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ConfNum < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "conf-num"
         mixed_content

--- a/lib/sts/niso_sts/conf_sponsor.rb
+++ b/lib/sts/niso_sts/conf_sponsor.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ConfSponsor < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "conf-sponsor"
         mixed_content

--- a/lib/sts/niso_sts/conf_theme.rb
+++ b/lib/sts/niso_sts/conf_theme.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ConfTheme < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "conf-theme"
         mixed_content

--- a/lib/sts/niso_sts/content_language.rb
+++ b/lib/sts/niso_sts/content_language.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class ContentLanguage < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :lang, :string
       attribute :specific_use, :string
 

--- a/lib/sts/niso_sts/contrib_id.rb
+++ b/lib/sts/niso_sts/contrib_id.rb
@@ -5,8 +5,7 @@ module Sts
     class ContribId < Lutaml::Model::Serializable
       attribute :contrib_id_type, :string
       attribute :authenticated, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "contrib-id"
         mixed_content

--- a/lib/sts/niso_sts/copyright_holder.rb
+++ b/lib/sts/niso_sts/copyright_holder.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class CopyrightHolder < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "copyright-holder"
         mixed_content

--- a/lib/sts/niso_sts/copyright_statement.rb
+++ b/lib/sts/niso_sts/copyright_statement.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class CopyrightStatement < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "copyright-statement"
         mixed_content

--- a/lib/sts/niso_sts/copyright_year.rb
+++ b/lib/sts/niso_sts/copyright_year.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class CopyrightYear < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "copyright-year"
         mixed_content

--- a/lib/sts/niso_sts/corresp.rb
+++ b/lib/sts/niso_sts/corresp.rb
@@ -5,8 +5,7 @@ module Sts
     class Corresp < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :xml_lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "corresp"
         mixed_content

--- a/lib/sts/niso_sts/country.rb
+++ b/lib/sts/niso_sts/country.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Country < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/data_title.rb
+++ b/lib/sts/niso_sts/data_title.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class DataTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/day.rb
+++ b/lib/sts/niso_sts/day.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Day < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "day"
         mixed_content

--- a/lib/sts/niso_sts/degrees.rb
+++ b/lib/sts/niso_sts/degrees.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Degrees < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/doc_number.rb
+++ b/lib/sts/niso_sts/doc_number.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class DocNumber < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "doc-number"
         mixed_content

--- a/lib/sts/niso_sts/doc_type.rb
+++ b/lib/sts/niso_sts/doc_type.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class DocType < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "doc-type"
         mixed_content

--- a/lib/sts/niso_sts/editing_instruction.rb
+++ b/lib/sts/niso_sts/editing_instruction.rb
@@ -6,7 +6,7 @@ module Sts
       attribute :id, :string
       attribute :xml_lang, :string
       attribute :specific_use, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :label, ::Sts::NisoSts::Label
 
       xml do

--- a/lib/sts/niso_sts/edition.rb
+++ b/lib/sts/niso_sts/edition.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Edition < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "edition"
         mixed_content

--- a/lib/sts/niso_sts/email.rb
+++ b/lib/sts/niso_sts/email.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Email < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/era.rb
+++ b/lib/sts/niso_sts/era.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Era < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "era"
         mixed_content

--- a/lib/sts/niso_sts/etal.rb
+++ b/lib/sts/niso_sts/etal.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Etal < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string

--- a/lib/sts/niso_sts/fax.rb
+++ b/lib/sts/niso_sts/fax.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Fax < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/floats_group.rb
+++ b/lib/sts/niso_sts/floats_group.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class FloatsGroup < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "floats-group"
         mixed_content

--- a/lib/sts/niso_sts/fpage.rb
+++ b/lib/sts/niso_sts/fpage.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Fpage < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/funding_source.rb
+++ b/lib/sts/niso_sts/funding_source.rb
@@ -8,8 +8,7 @@ module Sts
       attribute :funder_id, :string
       attribute :institution_id_type, :string
       attribute :xlink_href, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "funding-source"
         mixed_content

--- a/lib/sts/niso_sts/funding_statement.rb
+++ b/lib/sts/niso_sts/funding_statement.rb
@@ -5,8 +5,7 @@ module Sts
     class FundingStatement < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :rid, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "funding-statement"
         mixed_content

--- a/lib/sts/niso_sts/given_names.rb
+++ b/lib/sts/niso_sts/given_names.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class GivenNames < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/gov.rb
+++ b/lib/sts/niso_sts/gov.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Gov < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/ics_desc.rb
+++ b/lib/sts/niso_sts/ics_desc.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class IcsDesc < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "ics-desc"
         mixed_content

--- a/lib/sts/niso_sts/inline_supplementary_material.rb
+++ b/lib/sts/niso_sts/inline_supplementary_material.rb
@@ -14,8 +14,7 @@ module Sts
       attribute :xlink_actuate, :string
       attribute :xlink_show, :string
       attribute :xlink_title, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "inline-supplementary-material"
         mixed_content

--- a/lib/sts/niso_sts/institution.rb
+++ b/lib/sts/niso_sts/institution.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Institution < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/institution_id.rb
+++ b/lib/sts/niso_sts/institution_id.rb
@@ -4,8 +4,7 @@ module Sts
   module NisoSts
     class InstitutionId < Lutaml::Model::Serializable
       attribute :institution_id_type, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "institution-id"
         mixed_content

--- a/lib/sts/niso_sts/intro.rb
+++ b/lib/sts/niso_sts/intro.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Intro < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "intro"
         mixed_content

--- a/lib/sts/niso_sts/isbn.rb
+++ b/lib/sts/niso_sts/isbn.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Isbn < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/issn.rb
+++ b/lib/sts/niso_sts/issn.rb
@@ -4,7 +4,7 @@ module Sts
   module NisoSts
     class Issn < Lutaml::Model::Serializable
       attribute :pub_type, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/issn_l.rb
+++ b/lib/sts/niso_sts/issn_l.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class IssnL < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/issue.rb
+++ b/lib/sts/niso_sts/issue.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Issue < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/kwd.rb
+++ b/lib/sts/niso_sts/kwd.rb
@@ -8,8 +8,7 @@ module Sts
       attribute :kwd_type, :string
       attribute :xml_lang, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "kwd"
         mixed_content

--- a/lib/sts/niso_sts/license_p.rb
+++ b/lib/sts/niso_sts/license_p.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class LicenseP < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "license-p"
         mixed_content

--- a/lib/sts/niso_sts/long_desc.rb
+++ b/lib/sts/niso_sts/long_desc.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :content_type, :string
       attribute :xml_lang, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "long-desc"
         mixed_content

--- a/lib/sts/niso_sts/lpage.rb
+++ b/lib/sts/niso_sts/lpage.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Lpage < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/main.rb
+++ b/lib/sts/niso_sts/main.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Main < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "main"
         mixed_content

--- a/lib/sts/niso_sts/milestone_end.rb
+++ b/lib/sts/niso_sts/milestone_end.rb
@@ -8,8 +8,7 @@ module Sts
       attribute :content_type, :string
       attribute :rationale, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "milestone-end"
         mixed_content

--- a/lib/sts/niso_sts/milestone_start.rb
+++ b/lib/sts/niso_sts/milestone_start.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :content_type, :string
       attribute :rationale, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "milestone-start"
         mixed_content

--- a/lib/sts/niso_sts/mixed_citation.rb
+++ b/lib/sts/niso_sts/mixed_citation.rb
@@ -4,7 +4,7 @@
 module Sts
   module NisoSts
     class MixedCitation < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :publication_type, :string
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true

--- a/lib/sts/niso_sts/monospace.rb
+++ b/lib/sts/niso_sts/monospace.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "monospace"
         mixed_content

--- a/lib/sts/niso_sts/month.rb
+++ b/lib/sts/niso_sts/month.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Month < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "month"
         mixed_content

--- a/lib/sts/niso_sts/on_behalf_of.rb
+++ b/lib/sts/niso_sts/on_behalf_of.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class OnBehalfOf < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/open_access.rb
+++ b/lib/sts/niso_sts/open_access.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class OpenAccess < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "open-access"
         mixed_content

--- a/lib/sts/niso_sts/originator.rb
+++ b/lib/sts/niso_sts/originator.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Originator < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "originator"
         mixed_content

--- a/lib/sts/niso_sts/overline.rb
+++ b/lib/sts/niso_sts/overline.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "overline"
         mixed_content

--- a/lib/sts/niso_sts/page_range.rb
+++ b/lib/sts/niso_sts/page_range.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class PageRange < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/paragraph.rb
+++ b/lib/sts/niso_sts/paragraph.rb
@@ -4,7 +4,7 @@ module Sts
   module NisoSts
     class Paragraph < Lutaml::Model::Serializable
       attribute :id, :string
-      attribute :text, :string
+      attribute :text, :string, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :uri, :string

--- a/lib/sts/niso_sts/part_number.rb
+++ b/lib/sts/niso_sts/part_number.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class PartNumber < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "part-number"
         mixed_content

--- a/lib/sts/niso_sts/part_of_speech.rb
+++ b/lib/sts/niso_sts/part_of_speech.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class PartOfSpeech < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "part-of-speech"
         mixed_content

--- a/lib/sts/niso_sts/patent.rb
+++ b/lib/sts/niso_sts/patent.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Patent < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/phone.rb
+++ b/lib/sts/niso_sts/phone.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Phone < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/postal_code.rb
+++ b/lib/sts/niso_sts/postal_code.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class PostalCode < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/prefix.rb
+++ b/lib/sts/niso_sts/prefix.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Prefix < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/preformat.rb
+++ b/lib/sts/niso_sts/preformat.rb
@@ -8,8 +8,7 @@ module Sts
       attribute :preformat_type, :string
       attribute :xml_space, :string
       attribute :language, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "preformat"
         mixed_content

--- a/lib/sts/niso_sts/price.rb
+++ b/lib/sts/niso_sts/price.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Price < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "price"
         mixed_content

--- a/lib/sts/niso_sts/principal_award_recipient.rb
+++ b/lib/sts/niso_sts/principal_award_recipient.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class PrincipalAwardRecipient < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "principal-award-recipient"
         mixed_content

--- a/lib/sts/niso_sts/principal_investigator.rb
+++ b/lib/sts/niso_sts/principal_investigator.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class PrincipalInvestigator < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "principal-investigator"
         mixed_content

--- a/lib/sts/niso_sts/private_char.rb
+++ b/lib/sts/niso_sts/private_char.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :description, :string
       attribute :name, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "private-char"
         mixed_content

--- a/lib/sts/niso_sts/product.rb
+++ b/lib/sts/niso_sts/product.rb
@@ -5,8 +5,7 @@ module Sts
     class Product < Lutaml::Model::Serializable
       attribute :product_type, :string
       attribute :xlink_href, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "product"
         mixed_content

--- a/lib/sts/niso_sts/proj_id.rb
+++ b/lib/sts/niso_sts/proj_id.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ProjId < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "proj-id"
         mixed_content

--- a/lib/sts/niso_sts/publisher_loc.rb
+++ b/lib/sts/niso_sts/publisher_loc.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class PublisherLoc < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/publisher_name.rb
+++ b/lib/sts/niso_sts/publisher_name.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class PublisherName < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/rb.rb
+++ b/lib/sts/niso_sts/rb.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Rb < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string

--- a/lib/sts/niso_sts/reference_standard.rb
+++ b/lib/sts/niso_sts/reference_standard.rb
@@ -7,7 +7,7 @@ module Sts
     class ReferenceStandard < Lutaml::Model::Serializable
       attribute :type, :string
       attribute :std_id, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :std_ref, ::Sts::NisoSts::StandardRef
       attribute :title, :string
       attribute :fn, ::Sts::NisoSts::Fn, collection: true

--- a/lib/sts/niso_sts/related_article.rb
+++ b/lib/sts/niso_sts/related_article.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class RelatedArticle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :ext_link_type, :string
       attribute :href, :xlink_href
       attribute :id, :string

--- a/lib/sts/niso_sts/related_object.rb
+++ b/lib/sts/niso_sts/related_object.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class RelatedObject < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :ext_link_type, :string
       attribute :href, :xlink_href
       attribute :id, :string

--- a/lib/sts/niso_sts/related_term.rb
+++ b/lib/sts/niso_sts/related_term.rb
@@ -4,8 +4,7 @@ module Sts
   module NisoSts
     class RelatedTerm < Lutaml::Model::Serializable
       attribute :related_term_type, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "related-term"
         mixed_content

--- a/lib/sts/niso_sts/release_version.rb
+++ b/lib/sts/niso_sts/release_version.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ReleaseVersion < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "release-version"
         mixed_content

--- a/lib/sts/niso_sts/release_version_id.rb
+++ b/lib/sts/niso_sts/release_version_id.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class ReleaseVersionId < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "release-version-id"
         mixed_content

--- a/lib/sts/niso_sts/role.rb
+++ b/lib/sts/niso_sts/role.rb
@@ -4,7 +4,7 @@ module Sts
   module NisoSts
     class Role < Lutaml::Model::Serializable
       attribute :content_type, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/roman.rb
+++ b/lib/sts/niso_sts/roman.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "roman"
         mixed_content

--- a/lib/sts/niso_sts/rp.rb
+++ b/lib/sts/niso_sts/rp.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Rp < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :id, :string
 
       xml do

--- a/lib/sts/niso_sts/rt.rb
+++ b/lib/sts/niso_sts/rt.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Rt < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :specific_use, :string

--- a/lib/sts/niso_sts/sans_serif.rb
+++ b/lib/sts/niso_sts/sans_serif.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sans-serif"
         mixed_content

--- a/lib/sts/niso_sts/sc.rb
+++ b/lib/sts/niso_sts/sc.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sc"
         mixed_content

--- a/lib/sts/niso_sts/sdo.rb
+++ b/lib/sts/niso_sts/sdo.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Sdo < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sdo"
         mixed_content

--- a/lib/sts/niso_sts/season.rb
+++ b/lib/sts/niso_sts/season.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Season < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "season"
         mixed_content

--- a/lib/sts/niso_sts/secretariat.rb
+++ b/lib/sts/niso_sts/secretariat.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Secretariat < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "secretariat"
         mixed_content

--- a/lib/sts/niso_sts/see.rb
+++ b/lib/sts/niso_sts/see.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class See < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :rid, :string

--- a/lib/sts/niso_sts/see_also.rb
+++ b/lib/sts/niso_sts/see_also.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class SeeAlso < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :content_type, :string
       attribute :id, :string
       attribute :rid, :string

--- a/lib/sts/niso_sts/self_uri.rb
+++ b/lib/sts/niso_sts/self_uri.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class SelfUri < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :href, :xlink_href
       attribute :content_type, :string
       attribute :language, :string

--- a/lib/sts/niso_sts/series.rb
+++ b/lib/sts/niso_sts/series.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "series"
         mixed_content

--- a/lib/sts/niso_sts/series_text.rb
+++ b/lib/sts/niso_sts/series_text.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "series-text"
         mixed_content

--- a/lib/sts/niso_sts/series_title.rb
+++ b/lib/sts/niso_sts/series_title.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "series-title"
         mixed_content

--- a/lib/sts/niso_sts/sig.rb
+++ b/lib/sts/niso_sts/sig.rb
@@ -4,8 +4,7 @@ module Sts
   module NisoSts
     class Sig < Lutaml::Model::Serializable
       attribute :graphic, ::Sts::NisoSts::Graphic
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sig"
         mixed_content

--- a/lib/sts/niso_sts/size.rb
+++ b/lib/sts/niso_sts/size.rb
@@ -4,8 +4,7 @@ module Sts
   module NisoSts
     class Size < Lutaml::Model::Serializable
       attribute :units, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "size"
         mixed_content

--- a/lib/sts/niso_sts/source.rb
+++ b/lib/sts/niso_sts/source.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Source < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/speaker.rb
+++ b/lib/sts/niso_sts/speaker.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Speaker < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "speaker"
         mixed_content

--- a/lib/sts/niso_sts/state.rb
+++ b/lib/sts/niso_sts/state.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class State < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/std_org_abbrev.rb
+++ b/lib/sts/niso_sts/std_org_abbrev.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class StdOrgAbbrev < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "std-org-abbrev"
         mixed_content

--- a/lib/sts/niso_sts/std_org_loc.rb
+++ b/lib/sts/niso_sts/std_org_loc.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class StdOrgLoc < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "std-org-loc"
         mixed_content

--- a/lib/sts/niso_sts/std_org_name.rb
+++ b/lib/sts/niso_sts/std_org_name.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class StdOrgName < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "std-org-name"
         mixed_content

--- a/lib/sts/niso_sts/std_organization.rb
+++ b/lib/sts/niso_sts/std_organization.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class StdOrganization < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "std-organization"
         mixed_content

--- a/lib/sts/niso_sts/strike.rb
+++ b/lib/sts/niso_sts/strike.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "strike"
         mixed_content

--- a/lib/sts/niso_sts/string_conf.rb
+++ b/lib/sts/niso_sts/string_conf.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class StringConf < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "string-conf"
         mixed_content

--- a/lib/sts/niso_sts/string_date.rb
+++ b/lib/sts/niso_sts/string_date.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class StringDate < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "string-date"
         mixed_content

--- a/lib/sts/niso_sts/string_name.rb
+++ b/lib/sts/niso_sts/string_name.rb
@@ -5,7 +5,7 @@ module Sts
     class StringName < Lutaml::Model::Serializable
       attribute :name_style, :string
       attribute :content_type, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/styled_content.rb
+++ b/lib/sts/niso_sts/styled_content.rb
@@ -8,8 +8,7 @@ module Sts
       attribute :toggle, :string
       attribute :specific_use, :string
       attribute :lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "styled-content"
         mixed_content

--- a/lib/sts/niso_sts/sub.rb
+++ b/lib/sts/niso_sts/sub.rb
@@ -5,8 +5,7 @@ module Sts
     class Sub < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sub"
         mixed_content

--- a/lib/sts/niso_sts/subject.rb
+++ b/lib/sts/niso_sts/subject.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :id, :string
       attribute :xml_lang, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "subject"
         mixed_content

--- a/lib/sts/niso_sts/subtitle.rb
+++ b/lib/sts/niso_sts/subtitle.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Subtitle < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "subtitle"
         mixed_content

--- a/lib/sts/niso_sts/suffix.rb
+++ b/lib/sts/niso_sts/suffix.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Suffix < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/sup.rb
+++ b/lib/sts/niso_sts/sup.rb
@@ -5,8 +5,7 @@ module Sts
     class Sup < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "sup"
         mixed_content

--- a/lib/sts/niso_sts/suppl_number.rb
+++ b/lib/sts/niso_sts/suppl_number.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class SupplNumber < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "suppl-number"
         mixed_content

--- a/lib/sts/niso_sts/suppl_type.rb
+++ b/lib/sts/niso_sts/suppl_type.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class SupplType < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "suppl-type"
         mixed_content

--- a/lib/sts/niso_sts/suppl_version.rb
+++ b/lib/sts/niso_sts/suppl_version.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class SupplVersion < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "suppl-version"
         mixed_content

--- a/lib/sts/niso_sts/supplement.rb
+++ b/lib/sts/niso_sts/supplement.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :suppl_type, :string
       attribute :suppl_version, :string
       attribute :xml_lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "supplement"
         mixed_content

--- a/lib/sts/niso_sts/surname.rb
+++ b/lib/sts/niso_sts/surname.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Surname < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/target.rb
+++ b/lib/sts/niso_sts/target.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "target"
         mixed_content

--- a/lib/sts/niso_sts/term.rb
+++ b/lib/sts/niso_sts/term.rb
@@ -6,7 +6,7 @@ module Sts
     class Term < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :rid, :string
-      attribute :text, :string
+      attribute :text, :string, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :uri, :string

--- a/lib/sts/niso_sts/term_head.rb
+++ b/lib/sts/niso_sts/term_head.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class TermHead < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "term-head"
         mixed_content

--- a/lib/sts/niso_sts/term_source.rb
+++ b/lib/sts/niso_sts/term_source.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class TermSource < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "term-source"
         mixed_content

--- a/lib/sts/niso_sts/tex_math.rb
+++ b/lib/sts/niso_sts/tex_math.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class TexMath < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "tex-math"
         mixed_content

--- a/lib/sts/niso_sts/textual_form.rb
+++ b/lib/sts/niso_sts/textual_form.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class TextualForm < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "textual-form"
         mixed_content

--- a/lib/sts/niso_sts/time_stamp.rb
+++ b/lib/sts/niso_sts/time_stamp.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class TimeStamp < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/title.rb
+++ b/lib/sts/niso_sts/title.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Title < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :inline_formula, Sts::NisoSts::InlineFormula, collection: true
 
       xml do

--- a/lib/sts/niso_sts/title_full.rb
+++ b/lib/sts/niso_sts/title_full.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class TitleFull < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :std, ::Sts::NisoSts::ReferenceStandard
 
       xml do

--- a/lib/sts/niso_sts/title_wrap.rb
+++ b/lib/sts/niso_sts/title_wrap.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class TitleFull < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :std, ::Sts::NisoSts::ReferenceStandard
 
       xml do

--- a/lib/sts/niso_sts/trans_source.rb
+++ b/lib/sts/niso_sts/trans_source.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class TransSource < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/trans_title.rb
+++ b/lib/sts/niso_sts/trans_title.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class TransTitle < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/underline.rb
+++ b/lib/sts/niso_sts/underline.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :id, :string
       attribute :specific_use, :string
       attribute :toggle, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "underline"
         mixed_content

--- a/lib/sts/niso_sts/unstructured_kwd_group.rb
+++ b/lib/sts/niso_sts/unstructured_kwd_group.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :kwd_group_type, :string
       attribute :xml_lang, :string
       attribute :specific_use, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "unstructured-kwd-group"
         mixed_content

--- a/lib/sts/niso_sts/uri.rb
+++ b/lib/sts/niso_sts/uri.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Uri < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/urn.rb
+++ b/lib/sts/niso_sts/urn.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Urn < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "urn"
         mixed_content

--- a/lib/sts/niso_sts/verse_line.rb
+++ b/lib/sts/niso_sts/verse_line.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class VerseLine < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "verse-line"
         mixed_content

--- a/lib/sts/niso_sts/version.rb
+++ b/lib/sts/niso_sts/version.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Version < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "version"
         mixed_content

--- a/lib/sts/niso_sts/volume.rb
+++ b/lib/sts/niso_sts/volume.rb
@@ -3,7 +3,7 @@
 module Sts
   module NisoSts
     class Volume < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
 

--- a/lib/sts/niso_sts/volume_id.rb
+++ b/lib/sts/niso_sts/volume_id.rb
@@ -6,8 +6,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :pub_id_type, :string
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "volume-id"
         mixed_content

--- a/lib/sts/niso_sts/volume_issue_group.rb
+++ b/lib/sts/niso_sts/volume_issue_group.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class VolumeIssueGroup < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "volume-issue-group"
         mixed_content

--- a/lib/sts/niso_sts/volume_series.rb
+++ b/lib/sts/niso_sts/volume_series.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class VolumeSeries < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "volume-series"
         mixed_content

--- a/lib/sts/niso_sts/xi/fallback.rb
+++ b/lib/sts/niso_sts/xi/fallback.rb
@@ -4,8 +4,7 @@ module Sts
   module NisoSts
     module Xi
       class Fallback < Lutaml::Model::Serializable
-        attribute :content, :string
-
+        attribute :content, :string, collection: true
         xml do
           element "xi:fallback"
           mixed_content

--- a/lib/sts/niso_sts/year.rb
+++ b/lib/sts/niso_sts/year.rb
@@ -3,8 +3,7 @@
 module Sts
   module NisoSts
     class Year < Lutaml::Model::Serializable
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "year"
         mixed_content

--- a/lib/sts/tbx_iso_tml/cross_reference.rb
+++ b/lib/sts/tbx_iso_tml/cross_reference.rb
@@ -3,8 +3,7 @@
 module Sts
   module TbxIsoTml
     class CrossReference < Lutaml::Model::Serializable
-      attribute :value, :string
-
+      attribute :value, :string, collection: true
       xml do
         element "crossReference"
         mixed_content

--- a/lib/sts/tbx_iso_tml/definition.rb
+++ b/lib/sts/tbx_iso_tml/definition.rb
@@ -5,7 +5,7 @@ module Sts
     class Definition < Lutaml::Model::Serializable
       attribute :entailed_term, ::Sts::TbxIsoTml::EntailedTerm, collection: true
       attribute :note, ::Sts::TbxIsoTml::Note
-      attribute :value, :string
+      attribute :value, :string, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic
       attribute :math, ::Sts::TbxIsoTml::Math
       attribute :sub, :string

--- a/lib/sts/tbx_iso_tml/example.rb
+++ b/lib/sts/tbx_iso_tml/example.rb
@@ -6,7 +6,7 @@ module Sts
   module TbxIsoTml
     class Example < Lutaml::Model::Serializable
       attribute :id, :string
-      attribute :value, :string
+      attribute :value, :string, collection: true
       attribute :entailed_term, ::Sts::TbxIsoTml::EntailedTerm, collection: true
       attribute :inline_formula, ::Sts::NisoSts::InlineFormula
 

--- a/lib/sts/tbx_iso_tml/italic.rb
+++ b/lib/sts/tbx_iso_tml/italic.rb
@@ -3,7 +3,7 @@
 module Sts
   module TbxIsoTml
     class Italic < Lutaml::Model::Serializable
-      attribute :value, :string
+      attribute :value, :string, collection: true
       attribute :sub, :string
 
       xml do

--- a/lib/sts/tbx_iso_tml/math.rb
+++ b/lib/sts/tbx_iso_tml/math.rb
@@ -4,7 +4,7 @@ module Sts
   module TbxIsoTml
     class Math < Lutaml::Model::Serializable
       attribute :id, :string
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :display, :string
       attribute :mrow, ::Sts::TbxIsoTml::Mrow
       attribute :msub, ::Sts::TbxIsoTml::Msub, collection: true

--- a/lib/sts/tbx_iso_tml/mrow.rb
+++ b/lib/sts/tbx_iso_tml/mrow.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Sts
   module TbxIsoTml
     class Mrow < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :mo, :string, collection: true
       attribute :mi, :string, collection: true
       attribute :mn, :string, collection: true

--- a/lib/sts/tbx_iso_tml/note.rb
+++ b/lib/sts/tbx_iso_tml/note.rb
@@ -4,7 +4,7 @@ module Sts
   module TbxIsoTml
     class Note < Lutaml::Model::Serializable
       attribute :id, :string
-      attribute :value, :string
+      attribute :value, :string, collection: true
       attribute :table_wrap, ::Sts::TbxIsoTml::TableWrap
       attribute :entailed_term, ::Sts::TbxIsoTml::EntailedTerm, collection: true
       attribute :math, ::Sts::TbxIsoTml::Math, collection: true

--- a/lib/sts/tbx_iso_tml/semantics.rb
+++ b/lib/sts/tbx_iso_tml/semantics.rb
@@ -7,8 +7,7 @@ module Sts
       attribute :mo, :string
       attribute :mtext, :string
       attribute :munder, ::Sts::TbxIsoTml::Munder
-      attribute :content, :string
-
+      attribute :content, :string, collection: true
       xml do
         element "semantics"
         mixed_content

--- a/lib/sts/tbx_iso_tml/source.rb
+++ b/lib/sts/tbx_iso_tml/source.rb
@@ -3,7 +3,7 @@
 module Sts
   module TbxIsoTml
     class Source < Lutaml::Model::Serializable
-      attribute :value, :string
+      attribute :value, :string, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic
 
       xml do

--- a/lib/sts/tbx_iso_tml/subject_field.rb
+++ b/lib/sts/tbx_iso_tml/subject_field.rb
@@ -3,8 +3,7 @@
 module Sts
   module TbxIsoTml
     class SubjectField < Lutaml::Model::Serializable
-      attribute :value, :string
-
+      attribute :value, :string, collection: true
       xml do
         element "subjectField"
         mixed_content

--- a/lib/sts/tbx_iso_tml/td.rb
+++ b/lib/sts/tbx_iso_tml/td.rb
@@ -3,7 +3,7 @@
 module Sts
   module TbxIsoTml
     class Td < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :align, :string
       attribute :scope, :string
       attribute :style, :string

--- a/lib/sts/tbx_iso_tml/term.rb
+++ b/lib/sts/tbx_iso_tml/term.rb
@@ -5,7 +5,7 @@ module Sts
     class Term < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :script, :string
-      attribute :value, :string
+      attribute :value, :string, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic
       attribute :bold, :string
       attribute :sub, :string

--- a/lib/sts/tbx_iso_tml/th.rb
+++ b/lib/sts/tbx_iso_tml/th.rb
@@ -3,7 +3,7 @@
 module Sts
   module TbxIsoTml
     class Th < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :colspan, :string
       attribute :align, :string
       attribute :scope, :string

--- a/spec/sts_element_spec.rb
+++ b/spec/sts_element_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Sts::NisoSts do
             "<source>J Test</source></element-citation>"
       citation = Sts::NisoSts::ElementCitation.from_xml(xml)
       expect(citation.publication_type).to eq("journal")
-      expect(citation.source.content).to eq("J Test")
+      expect(citation.source.content).to eq(["J Test"])
     end
 
     it "round-trips Contrib through xml" do


### PR DESCRIPTION
## Summary
- Add `collection: true` to all `map_content` attributes used with `mixed_content`
- Required by lutaml-model `MixedContentCollectionError` validation (lutaml/lutaml-model#647)

## Why
When `mixed_content` is enabled with `map_content`, the content attribute must be a string collection to properly handle multiple interleaved text nodes in XML. Without `collection: true`, text nodes beyond the first are silently dropped during deserialization.

## Affected models
205 models across `IsoSts`, `NisoSts`, `TbxIsoTml` namespaces.