### PR TITLE
fix: remove explicit namespace nil from TBX Bold and Italic

### DIFF
--- a/lib/sts/tbx_iso_tml/bold.rb
+++ b/lib/sts/tbx_iso_tml/bold.rb
@@ -7,7 +7,6 @@ module Sts
 
       xml do
         element "bold"
-        namespace nil, nil
 
         map_content to: :value
       end

--- a/lib/sts/tbx_iso_tml/italic.rb
+++ b/lib/sts/tbx_iso_tml/italic.rb
@@ -9,7 +9,6 @@ module Sts
       xml do
         element "italic"
         mixed_content
-        namespace nil, nil
 
         map_content to: :value
         map_element "sub", to: :sub


### PR DESCRIPTION
## Summary
- Remove `namespace nil, nil` declarations from `TbxIsoTml::Bold` and `TbxIsoTml::Italic` elements
- These explicit nil namespace declarations were interfering with XML round-tripping by overriding the inherited namespace context from parent elements

## Test plan
- [ ] Verify XML round-tripping of Bold and Italic elements works correctly
- [ ] Run `bundle exec rake` to confirm all existing tests pass