### PR TITLE
chore(ci): cimas sync 2026-06-24 — required_ruby_version >= 3.3, automerge v0.16.4 pin, lutaml Makefile (refs metanorma/ci#274 #283 #281 #300)

### DIFF
--- a/sts.gemspec
+++ b/sts.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Library to work with NISO STS and ISOSTS."
   spec.homepage      = "https://github.com/metanorma/sts-ruby"
   spec.license       = "BSD-2-Clause"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.