### PR TITLE
Restore @id and dropped ISOSTS attributes on IsoSts models

### DIFF
--- a/TODO.sts-refactor/00-overview.md
+++ b/TODO.sts-refactor/00-overview.md
@@ -196,5 +196,6 @@ Two independent tracks:
 1. Finish `03` — the 20 remaining refs split into 11 deep-root refs (each
    reaching a ~152-class recursive core) and 9 child-bearing refs whose closure
    is unmeasured. Both need sizing before planning.
-2. File and fix the 16 lossy models above — real data loss, unrelated to
-   decoupling.
+2. The remaining schema-conformance follow-up above — the 7 spurious attributes
+   on 5 models and the 6 classes without `@id`. (The dropped-attribute data loss
+   is now fixed.)

--- a/TODO.sts-refactor/00-overview.md
+++ b/TODO.sts-refactor/00-overview.md
@@ -167,21 +167,23 @@ grep -r "method_missing|respond_to_missing|Object.const_get|\.send" lib/
 
 ### Architectural Items (High Effort)
 - `03-namespace-coupling.md` — IN PROGRESS: 63→20 IsoSts→NisoSts references
-  remaining (issue #40). Source of truth is `ISOSTS.xsd`, NOT the NisoSts
-  models — they disagree on nearly every element.
+  remaining (issue #40). ISOSTS.xsd governs content models and all non-`@id`
+  attributes; the `@id` follows the 86948b9 convention.
 - `04-register-versioning.md` — Version the models via lutaml-model Registers
 - `11-duplicate-models.md` — 44 overlapping element resolution (depends on 03)
 
 ### Known bugs — schema conformance (separate from 03)
 The 2026-05-07 "@id added to all models (XSD-verified)" pass verified against
-the **NISO** XSD and applied the result to IsoSts. ISOSTS disagrees:
-- **16 IsoSts models silently drop ISOSTS attributes that exist** — real data
-  loss. `sub`/`sup` lose `arrange`+`specific-use`; `ext-link` loses 5 xlink
-  attrs; `mixed-citation` loses 6; `graphic`, `copyright-*`, `edition`,
-  `title`, `label`, `uri`, `named-content`, `underline`, `meta-date`, `body`
-  lose others.
-- **25 IsoSts models carry an `@id` ISOSTS does not define** — harmless (never
-  populated on parse, never emitted on serialise), but dead surface.
+the **NISO** XSD and applied the result to IsoSts.
+- **Real bug — dropped ISOSTS attributes.** Some IsoSts models silently drop
+  ISOSTS attributes that exist in real documents — real data loss. `sub`/`sup`
+  lose `arrange`+`specific-use`; `ext-link` loses its `xlink:*` set;
+  `mixed-citation` loses several; `graphic`, `copyright-*`, `edition`, `title`,
+  `label`, `uri`, `named-content`, `underline`, `meta-date`, `body` lose
+  others. Regenerate the exact `name=`+`ref=` table when filing the issue.
+- **Not a bug — the conventional `@id`.** IsoSts models carry an `@id` that
+  ISOSTS does not itself define; this is the deliberate 86948b9 convention
+  (NISO-XSD-verified), not dead surface.
 
 ## Next Action
 Two independent tracks:

--- a/TODO.sts-refactor/00-overview.md
+++ b/TODO.sts-refactor/00-overview.md
@@ -172,18 +172,24 @@ grep -r "method_missing|respond_to_missing|Object.const_get|\.send" lib/
 - `04-register-versioning.md` — Version the models via lutaml-model Registers
 - `11-duplicate-models.md` — 44 overlapping element resolution (depends on 03)
 
-### Known bugs — schema conformance (separate from 03)
+### Schema conformance — dropped ISOSTS attributes
 The 2026-05-07 "@id added to all models (XSD-verified)" pass verified against
 the **NISO** XSD and applied the result to IsoSts.
-- **Real bug — dropped ISOSTS attributes.** Some IsoSts models silently drop
-  ISOSTS attributes that exist in real documents — real data loss. `sub`/`sup`
-  lose `arrange`+`specific-use`; `ext-link` loses its `xlink:*` set;
-  `mixed-citation` loses several; `graphic`, `copyright-*`, `edition`, `title`,
-  `label`, `uri`, `named-content`, `underline`, `meta-date`, `body` lose
-  others. Regenerate the exact `name=`+`ref=` table when filing the issue.
+- **Fixed — dropped ISOSTS attributes restored.** 15 IsoSts models were
+  silently dropping ISOSTS attributes present in real documents (data loss):
+  `sub`/`sup` (`arrange`+`specific-use`), `ext-link`/`mixed-citation`/`uri`/
+  `named-content` (`xlink:*`), `graphic` (`xlink:*`+`originator`), `copyright-*`,
+  `edition`, `title`, `label`, `underline`, `body`. This change adds them and
+  fixes `sec`/`standard`/`term-sec`, which mapped `xml:lang` under the wrong XML
+  name. (`meta-date` was NOT lossy — it already maps `type`.)
 - **Not a bug — the conventional `@id`.** IsoSts models carry an `@id` that
   ISOSTS does not itself define; this is the deliberate 86948b9 convention
   (NISO-XSD-verified), not dead surface.
+- **Remaining follow-up (separate change).** 7 spurious attributes on 5 models
+  (model carries an attr ISOSTS does not define: `graphic` `type`, `body`/`back`
+  `content-type`, `content-language`/`language` extras), and the 6 classes left
+  without `@id` in 86948b9 (`monospace`, `sc`, `strike`, `underline`, `uri`,
+  `standard_ref`).
 
 ## Next Action
 Two independent tracks:

--- a/TODO.sts-refactor/03-namespace-coupling.md
+++ b/TODO.sts-refactor/03-namespace-coupling.md
@@ -14,41 +14,42 @@ evolves, so coupling them violates OCP.
 PR #31 reduced this from 157 to 63 references. Issue #40 reduced it further,
 from 63 to 20.
 
-## Source of truth: ISOSTS.xsd, NOT the NisoSts models
+## Content models from ISOSTS.xsd; `@id` from the 86948b9 convention
 
-The obvious approach — duplicate each NisoSts class into IsoSts — produces
-**schema-incorrect models**. The NisoSts models disagree with
-`reference-docs/isosts-v1/xsd/ISOSTS.xsd` on nearly every element:
+IsoSts models carry `@id` following the compatibility convention established in
+86948b9 (NISO-XSD-verified). ISOSTS.xsd governs element content
+models and all non-`@id` attributes; it is not an authority that forbids the
+conventional `@id`. So the two schemas can legitimately differ per element:
 
-| Element | ISOSTS says | NisoSts model |
+| Element | ISOSTS content/attrs | NisoSts model |
 |---|---|---|
-| `year` (:948) | `content-type`, `specific-use`, `xml:lang` — no `@id` | `@id` only |
-| `doc-type` (:6378) | `type="xs:string"` — no attributes at all | `@id` + content |
+| `doc-type` (:6378) | `type="xs:string"` | `@id` + content |
 | `ics` (:6373) | `type="xs:string"` | `@id` + `ics-desc` child |
 | `fpage` | `content-type`, `seq`, `specific-use`, `xml:lang`; no children | `@id` + bold/italic |
 | `license` (:51) | `license-type`, `specific-use`, `xml:lang` | `@id`, `xlink:href` |
-| `ruby` | **not an ISOSTS element** | exists (NISO only) |
 
 `feature_doc.xml` declares `<!DOCTYPE standard SYSTEM ".../ISOSTS.dtd">`, and
 the ISOSTS DTD agrees with ISOSTS.xsd (both derive `bold`, `sub` etc. from the
-JATS 0.4 modules). ISOSTS.xsd is a faithful conversion and is the authority.
+JATS 0.4 modules) on content models.
 
 **Round-tripping does not prove correctness.** A model that invents or drops an
 attribute still parses and serialises symmetrically, so the suite stays green
 while the model is wrong. Assert the exact attribute set per element instead.
 
-Attribute lists must be **generated** from the XSD, never hand-read: `version`
-on `tex-math` and `specific-use` on `pub-id` sit after long `xs:enumeration`
-blocks and are invisible to a truncated read.
+Non-`@id` attribute lists must be **generated** from the XSD, never hand-read:
+`version` on `tex-math` and `specific-use` on `pub-id` sit after long
+`xs:enumeration` blocks and are invisible to a truncated read.
 
 ## Done in issue #40 — 43 refs removed, 27 classes added
 
 - **14 `xs:string` elements** (`originator`, `doc-type`, `doc-number`,
   `part-number`, `version`, `suppl-type`, `suppl-number`, `suppl-version`,
   `urn`, `sdo`, `proj-id`, `release-version`, `ics`, `secretariat`) — modelled
-  as content-only IsoSts classes with no attributes. 23 refs.
+  as content IsoSts classes that also carry the conventional `@id` (86948b9);
+  `secretariat` is content plus `@id`, not content-only. 23 refs.
 - **3 `permissions` refs** repointed to the existing `IsoSts::Permissions`.
-- **`ruby` deleted** from `StyledContent` — ISOSTS defines no such element.
+- **`ruby` deleted** from `StyledContent` — ISOSTS's `styled-content` content
+  model omits `<ruby>` (NISO permits it transitively via the emphasis group).
   Behaviour change: `<ruby>` in `<styled-content>` no longer round-trips.
 - **13 element classes** modelled from ISOSTS.xsd: `Year`, `PubDate`,
   `ReleaseVersionId`, `IsProof`, `AltText`, `LongDesc`, `TexMath`, `PubId`,
@@ -114,6 +115,7 @@ reaches `TbxIsoTml`/MathML. Those are shared namespaces, outside this ADR.
 ## Verification
 
 1. `grep -rho "Sts::NisoSts::" lib/sts/iso_sts/ | wc -l` → `20`
-2. Every attribute on an IsoSts model traces to a line in `ISOSTS.xsd`
+2. Every *non-`@id`* attribute on an IsoSts model traces to a line in
+   `ISOSTS.xsd`; `@id` follows the 86948b9 convention
 3. Autoload registry 1:1 with the directory (112/112)
 4. `bundle exec rspec` green; `bundle exec rubocop` clean

--- a/lib/sts/iso_sts/body.rb
+++ b/lib/sts/iso_sts/body.rb
@@ -5,6 +5,7 @@ module Sts
     class Body < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :content_type, :string
+      attribute :specific_use, :string
       attribute :paragraph, ::Sts::IsoSts::Paragraph, collection: true
       attribute :sec, ::Sts::IsoSts::Sec, collection: true
       attribute :term_sec, ::Sts::IsoSts::TermSec, collection: true
@@ -31,6 +32,7 @@ module Sts
 
         map_attribute "id", to: :id
         map_attribute "content-type", to: :content_type
+        map_attribute "specific-use", to: :specific_use
 
         map_element "p", to: :paragraph
         map_element "sec", to: :sec

--- a/lib/sts/iso_sts/copyright_holder.rb
+++ b/lib/sts/iso_sts/copyright_holder.rb
@@ -4,6 +4,9 @@ module Sts
   module IsoSts
     class CopyrightHolder < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :content_type, :string
+      attribute :specific_use, :string
+      attribute :xml_lang, :string
       attribute :content, :string, collection: true
       attribute :sub, ::Sts::IsoSts::Sub
       attribute :sup, ::Sts::IsoSts::Sup
@@ -11,6 +14,9 @@ module Sts
       xml do
         element "copyright-holder"
         map_attribute "id", to: :id
+        map_attribute "content-type", to: :content_type
+        map_attribute "specific-use", to: :specific_use
+        map_attribute "xml:lang", to: :xml_lang
         mixed_content
 
         map_content to: :content

--- a/lib/sts/iso_sts/copyright_statement.rb
+++ b/lib/sts/iso_sts/copyright_statement.rb
@@ -4,6 +4,9 @@ module Sts
   module IsoSts
     class CopyrightStatement < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :content_type, :string
+      attribute :specific_use, :string
+      attribute :xml_lang, :string
       attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
@@ -13,6 +16,9 @@ module Sts
       xml do
         element "copyright-statement"
         map_attribute "id", to: :id
+        map_attribute "content-type", to: :content_type
+        map_attribute "specific-use", to: :specific_use
+        map_attribute "xml:lang", to: :xml_lang
         mixed_content
 
         map_content to: :content

--- a/lib/sts/iso_sts/copyright_year.rb
+++ b/lib/sts/iso_sts/copyright_year.rb
@@ -4,12 +4,16 @@ module Sts
   module IsoSts
     class CopyrightYear < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :content_type, :string
+      attribute :specific_use, :string
       attribute :content, :string
 
       xml do
         element "copyright-year"
 
         map_attribute "id", to: :id
+        map_attribute "content-type", to: :content_type
+        map_attribute "specific-use", to: :specific_use
 
         map_content to: :content
       end

--- a/lib/sts/iso_sts/doc_number.rb
+++ b/lib/sts/iso_sts/doc_number.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <doc-number> as type="xs:string" -- no attributes.
+    # ISOSTS declares <doc-number> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class DocNumber < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "doc-number"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/doc_type.rb
+++ b/lib/sts/iso_sts/doc_type.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <doc-type> as type="xs:string" -- no attributes.
+    # ISOSTS declares <doc-type> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class DocType < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "doc-type"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/edition.rb
+++ b/lib/sts/iso_sts/edition.rb
@@ -4,10 +4,16 @@ module Sts
   module IsoSts
     class Edition < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :content_type, :string
+      attribute :specific_use, :string
+      attribute :xml_lang, :string
       attribute :content, :string, collection: true
       xml do
         element "edition"
         map_attribute "id", to: :id
+        map_attribute "content-type", to: :content_type
+        map_attribute "specific-use", to: :specific_use
+        map_attribute "xml:lang", to: :xml_lang
         mixed_content
 
         map_content to: :content

--- a/lib/sts/iso_sts/ext_link.rb
+++ b/lib/sts/iso_sts/ext_link.rb
@@ -8,6 +8,11 @@ module Sts
       attribute :specific_use, :string
       attribute :xml_lang, :string
       attribute :xlink_href, :string
+      attribute :xlink_type, :string
+      attribute :xlink_role, :string
+      attribute :xlink_title, :string
+      attribute :xlink_show, :string
+      attribute :xlink_actuate, :string
       attribute :content, :string
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
@@ -21,6 +26,11 @@ module Sts
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
         map_attribute "xlink:href", to: :xlink_href
+        map_attribute "xlink:type", to: :xlink_type
+        map_attribute "xlink:role", to: :xlink_role
+        map_attribute "xlink:title", to: :xlink_title
+        map_attribute "xlink:show", to: :xlink_show
+        map_attribute "xlink:actuate", to: :xlink_actuate
 
         map_content to: :content
 

--- a/lib/sts/iso_sts/fpage.rb
+++ b/lib/sts/iso_sts/fpage.rb
@@ -8,6 +8,7 @@ module Sts
       attribute :seq, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
+      attribute :id, :string
 
       xml do
         element "fpage"
@@ -17,6 +18,7 @@ module Sts
         map_attribute "seq", to: :seq
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/graphic.rb
+++ b/lib/sts/iso_sts/graphic.rb
@@ -13,7 +13,12 @@ module Sts
       attribute :mime_subtype, :string
       attribute :xlink_href, :string
       attribute :xlink_type, :string
+      attribute :xlink_role, :string
+      attribute :xlink_title, :string
+      attribute :xlink_show, :string
+      attribute :xlink_actuate, :string
       attribute :graphic_type, :string
+      attribute :originator, :string
       attribute :label, ::Sts::IsoSts::Label
       attribute :caption, ::Sts::IsoSts::Caption
       attribute :alt_text, ::Sts::IsoSts::AltText
@@ -33,7 +38,12 @@ module Sts
         map_attribute "mime-subtype", to: :mime_subtype
         map_attribute "xlink:href", to: :xlink_href
         map_attribute "xlink:type", to: :xlink_type
+        map_attribute "xlink:role", to: :xlink_role
+        map_attribute "xlink:title", to: :xlink_title
+        map_attribute "xlink:show", to: :xlink_show
+        map_attribute "xlink:actuate", to: :xlink_actuate
         map_attribute "type", to: :graphic_type
+        map_attribute "originator", to: :originator
 
         map_element "label", to: :label
         map_element "caption", to: :caption

--- a/lib/sts/iso_sts/ics.rb
+++ b/lib/sts/iso_sts/ics.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <ics> as type="xs:string" -- no attributes.
+    # ISOSTS declares <ics> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class Ics < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "ics"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/is_proof.rb
+++ b/lib/sts/iso_sts/is_proof.rb
@@ -2,11 +2,16 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <is-proof> as an empty complexType: its presence is the
-    # whole signal -- no attributes, no content.
+    # ISOSTS declares <is-proof> as an empty complexType: its presence carries
+    # no content. The @id follows the NisoSts convention established in 86948b9,
+    # not ISOSTS itself.
     class IsProof < Lutaml::Model::Serializable
+      attribute :id, :string
+
       xml do
         element "is-proof"
+
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/issue.rb
+++ b/lib/sts/iso_sts/issue.rb
@@ -8,6 +8,7 @@ module Sts
       attribute :seq, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
+      attribute :id, :string
 
       xml do
         element "issue"
@@ -17,6 +18,7 @@ module Sts
         map_attribute "seq", to: :seq
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/label.rb
+++ b/lib/sts/iso_sts/label.rb
@@ -4,6 +4,8 @@ module Sts
   module IsoSts
     class Label < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :alt, :string
+      attribute :xml_lang, :string
       attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
@@ -19,6 +21,8 @@ module Sts
       xml do
         element "label"
         map_attribute "id", to: :id
+        map_attribute "alt", to: :alt
+        map_attribute "xml:lang", to: :xml_lang
         mixed_content
 
         map_content to: :content

--- a/lib/sts/iso_sts/lpage.rb
+++ b/lib/sts/iso_sts/lpage.rb
@@ -7,6 +7,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
+      attribute :id, :string
 
       xml do
         element "lpage"
@@ -15,6 +16,7 @@ module Sts
         map_attribute "content-type", to: :content_type
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/mixed_citation.rb
+++ b/lib/sts/iso_sts/mixed_citation.rb
@@ -9,6 +9,12 @@ module Sts
       attribute :publication_format, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
+      attribute :xlink_type, :string
+      attribute :xlink_href, :string
+      attribute :xlink_role, :string
+      attribute :xlink_title, :string
+      attribute :xlink_show, :string
+      attribute :xlink_actuate, :string
       attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold, collection: true
       attribute :italic, ::Sts::IsoSts::Italic, collection: true
@@ -35,7 +41,7 @@ module Sts
       attribute :publisher, ::Sts::NisoSts::Publisher
       attribute :pub_id, ::Sts::IsoSts::PubId, collection: true
 
-      xml do
+      xml do # rubocop:disable Metrics/BlockLength
         element "mixed-citation"
         mixed_content
 
@@ -45,6 +51,12 @@ module Sts
         map_attribute "publication-format", to: :publication_format
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
+        map_attribute "xlink:type", to: :xlink_type
+        map_attribute "xlink:href", to: :xlink_href
+        map_attribute "xlink:role", to: :xlink_role
+        map_attribute "xlink:title", to: :xlink_title
+        map_attribute "xlink:show", to: :xlink_show
+        map_attribute "xlink:actuate", to: :xlink_actuate
 
         map_content to: :content
 

--- a/lib/sts/iso_sts/named_content.rb
+++ b/lib/sts/iso_sts/named_content.rb
@@ -9,6 +9,7 @@ module Sts
       attribute :specific_use, :string
       attribute :xml_lang, :string
       attribute :xlink_href, :string
+      attribute :xlink_type, :string
       attribute :xlink_role, :string
       attribute :xlink_title, :string
       attribute :xlink_show, :string
@@ -29,6 +30,7 @@ module Sts
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
         map_attribute "xlink:href", to: :xlink_href
+        map_attribute "xlink:type", to: :xlink_type
         map_attribute "xlink:role", to: :xlink_role
         map_attribute "xlink:title", to: :xlink_title
         map_attribute "xlink:show", to: :xlink_show

--- a/lib/sts/iso_sts/originator.rb
+++ b/lib/sts/iso_sts/originator.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <originator> as type="xs:string" -- no attributes.
+    # ISOSTS declares <originator> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class Originator < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "originator"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/page_range.rb
+++ b/lib/sts/iso_sts/page_range.rb
@@ -7,6 +7,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
+      attribute :id, :string
 
       xml do
         element "page-range"
@@ -15,6 +16,7 @@ module Sts
         map_attribute "content-type", to: :content_type
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/part_number.rb
+++ b/lib/sts/iso_sts/part_number.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <part-number> as type="xs:string" -- no attributes.
+    # ISOSTS declares <part-number> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class PartNumber < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "part-number"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/proj_id.rb
+++ b/lib/sts/iso_sts/proj_id.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <proj-id> as type="xs:string" -- no attributes.
+    # ISOSTS declares <proj-id> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class ProjId < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "proj-id"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/pub_date.rb
+++ b/lib/sts/iso_sts/pub_date.rb
@@ -5,12 +5,14 @@ module Sts
     class PubDate < Lutaml::Model::Serializable
       attribute :content, :string
       attribute :pub_type, :string
+      attribute :id, :string
 
       xml do
         element "pub-date"
 
         map_content to: :content
         map_attribute "pub-type", to: :pub_type
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/pub_id.rb
+++ b/lib/sts/iso_sts/pub_id.rb
@@ -6,6 +6,7 @@ module Sts
       attribute :content, :string
       attribute :pub_id_type, :string
       attribute :specific_use, :string
+      attribute :id, :string
 
       xml do
         element "pub-id"
@@ -13,6 +14,7 @@ module Sts
         map_content to: :content
         map_attribute "pub-id-type", to: :pub_id_type
         map_attribute "specific-use", to: :specific_use
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/release_version.rb
+++ b/lib/sts/iso_sts/release_version.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <release-version> as type="xs:string" -- no attributes.
+    # ISOSTS declares <release-version> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class ReleaseVersion < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "release-version"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/sdo.rb
+++ b/lib/sts/iso_sts/sdo.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <sdo> as type="xs:string" -- no attributes.
+    # ISOSTS declares <sdo> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class Sdo < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "sdo"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/sec.rb
+++ b/lib/sts/iso_sts/sec.rb
@@ -44,7 +44,7 @@ module Sts
         ordered
 
         map_attribute "id", to: :id
-        map_attribute "lang", to: :xml_lang
+        map_attribute "xml:lang", to: :xml_lang
         map_attribute "sec-type", to: :sec_type
         map_attribute "specific-use", to: :specific_use
         map_attribute "originator", to: :originator

--- a/lib/sts/iso_sts/secretariat.rb
+++ b/lib/sts/iso_sts/secretariat.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <secretariat> as type="xs:string" -- no attributes.
+    # ISOSTS declares <secretariat> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class Secretariat < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "secretariat"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/standard.rb
+++ b/lib/sts/iso_sts/standard.rb
@@ -4,7 +4,7 @@ module Sts
   module IsoSts
     class Standard < Lutaml::Model::Serializable
       attribute :id, :string
-      attribute :lang, :string
+      attribute :xml_lang, :string
       attribute :dtd_version, :string
       attribute :specific_use, :string
       attribute :front, ::Sts::IsoSts::Front
@@ -20,7 +20,7 @@ module Sts
           ::Lutaml::Xml::W3c::XlinkNamespace,
         ]
         map_attribute "id", to: :id
-        map_attribute "lang", to: :lang
+        map_attribute "xml:lang", to: :xml_lang
         map_attribute "dtd-version", to: :dtd_version
         map_attribute "specific-use", to: :specific_use
 

--- a/lib/sts/iso_sts/sub.rb
+++ b/lib/sts/iso_sts/sub.rb
@@ -4,10 +4,14 @@ module Sts
   module IsoSts
     class Sub < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :arrange, :string
+      attribute :specific_use, :string
       attribute :content, :string, collection: true
       xml do
         element "sub"
         map_attribute "id", to: :id
+        map_attribute "arrange", to: :arrange
+        map_attribute "specific-use", to: :specific_use
         mixed_content
 
         map_content to: :content

--- a/lib/sts/iso_sts/sup.rb
+++ b/lib/sts/iso_sts/sup.rb
@@ -4,10 +4,14 @@ module Sts
   module IsoSts
     class Sup < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :arrange, :string
+      attribute :specific_use, :string
       attribute :content, :string, collection: true
       xml do
         element "sup"
         map_attribute "id", to: :id
+        map_attribute "arrange", to: :arrange
+        map_attribute "specific-use", to: :specific_use
         mixed_content
 
         map_content to: :content

--- a/lib/sts/iso_sts/suppl_number.rb
+++ b/lib/sts/iso_sts/suppl_number.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <suppl-number> as type="xs:string" -- no attributes.
+    # ISOSTS declares <suppl-number> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class SupplNumber < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "suppl-number"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/suppl_type.rb
+++ b/lib/sts/iso_sts/suppl_type.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <suppl-type> as type="xs:string" -- no attributes.
+    # ISOSTS declares <suppl-type> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class SupplType < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "suppl-type"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/suppl_version.rb
+++ b/lib/sts/iso_sts/suppl_version.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <suppl-version> as type="xs:string" -- no attributes.
+    # ISOSTS declares <suppl-version> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class SupplVersion < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "suppl-version"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/term_sec.rb
+++ b/lib/sts/iso_sts/term_sec.rb
@@ -27,7 +27,7 @@ module Sts
         ordered
 
         map_attribute "id", to: :id
-        map_attribute "lang", to: :xml_lang
+        map_attribute "xml:lang", to: :xml_lang
         map_attribute "sec-type", to: :sec_type
         map_attribute "specific-use", to: :specific_use
         map_attribute "originator", to: :originator

--- a/lib/sts/iso_sts/title.rb
+++ b/lib/sts/iso_sts/title.rb
@@ -4,6 +4,8 @@ module Sts
   module IsoSts
     class Title < Lutaml::Model::Serializable
       attribute :id, :string
+      attribute :content_type, :string
+      attribute :specific_use, :string
       attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold, collection: true
       attribute :italic, ::Sts::IsoSts::Italic, collection: true
@@ -20,6 +22,8 @@ module Sts
       xml do
         element "title"
         map_attribute "id", to: :id
+        map_attribute "content-type", to: :content_type
+        map_attribute "specific-use", to: :specific_use
         mixed_content
 
         map_content to: :content

--- a/lib/sts/iso_sts/underline.rb
+++ b/lib/sts/iso_sts/underline.rb
@@ -3,6 +3,7 @@
 module Sts
   module IsoSts
     class Underline < Lutaml::Model::Serializable
+      attribute :underline_style, :string
       attribute :specific_use, :string
       attribute :content, :string, collection: true
       attribute :bold, ::Sts::IsoSts::Bold, collection: true
@@ -14,6 +15,7 @@ module Sts
         element "underline"
         mixed_content
 
+        map_attribute "underline-style", to: :underline_style
         map_attribute "specific-use", to: :specific_use
         map_content to: :content
         map_element "bold", to: :bold

--- a/lib/sts/iso_sts/uri.rb
+++ b/lib/sts/iso_sts/uri.rb
@@ -7,6 +7,7 @@ module Sts
       attribute :specific_use, :string
       attribute :xml_lang, :string
       attribute :xlink_href, :string
+      attribute :xlink_type, :string
       attribute :xlink_role, :string
       attribute :xlink_title, :string
       attribute :xlink_show, :string
@@ -21,6 +22,7 @@ module Sts
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
         map_attribute "xlink:href", to: :xlink_href
+        map_attribute "xlink:type", to: :xlink_type
         map_attribute "xlink:role", to: :xlink_role
         map_attribute "xlink:title", to: :xlink_title
         map_attribute "xlink:show", to: :xlink_show

--- a/lib/sts/iso_sts/urn.rb
+++ b/lib/sts/iso_sts/urn.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <urn> as type="xs:string" -- no attributes.
+    # ISOSTS declares <urn> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class Urn < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "urn"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/version.rb
+++ b/lib/sts/iso_sts/version.rb
@@ -2,14 +2,17 @@
 
 module Sts
   module IsoSts
-    # ISOSTS declares <version> as type="xs:string" -- no attributes.
+    # ISOSTS declares <version> as type="xs:string". The @id follows the
+    # NisoSts convention established in 86948b9, not ISOSTS itself.
     class Version < Lutaml::Model::Serializable
       attribute :content, :string
+      attribute :id, :string
 
       xml do
         element "version"
 
         map_content to: :content
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/volume.rb
+++ b/lib/sts/iso_sts/volume.rb
@@ -8,6 +8,7 @@ module Sts
       attribute :seq, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
+      attribute :id, :string
 
       xml do
         element "volume"
@@ -17,6 +18,7 @@ module Sts
         map_attribute "seq", to: :seq
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
+        map_attribute "id", to: :id
       end
     end
   end

--- a/lib/sts/iso_sts/year.rb
+++ b/lib/sts/iso_sts/year.rb
@@ -7,6 +7,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
+      attribute :id, :string
 
       xml do
         element "year"
@@ -15,6 +16,7 @@ module Sts
         map_attribute "content-type", to: :content_type
         map_attribute "specific-use", to: :specific_use
         map_attribute "xml:lang", to: :xml_lang
+        map_attribute "id", to: :id
       end
     end
   end

--- a/spec/iso_sts/iso_sts_element_spec.rb
+++ b/spec/iso_sts/iso_sts_element_spec.rb
@@ -428,10 +428,10 @@ RSpec.describe Sts::IsoSts do
     end
   end
 
-  # ISOSTS declares these elements as type="xs:string": text content, no
-  # attributes. They are modelled as IsoSts classes rather than plain strings
-  # because an empty element (<sdo/>) does not survive a :string round-trip --
-  # for a collection it parses to [], losing the element entirely.
+  # ISOSTS declares these elements as type="xs:string": text content, plus the
+  # conventional @id (86948b9). They are modelled as IsoSts classes rather than
+  # plain strings because an empty element (<sdo/>) does not survive a :string
+  # round-trip -- for a collection it parses to [], losing the element entirely.
   describe "ISOSTS xs:string elements" do
     {
       Originator: "originator",
@@ -454,9 +454,9 @@ RSpec.describe Sts::IsoSts do
         expect(model.mappings_for(:xml).root_element).to eq(element)
       end
 
-      it "IsoSts::#{klass} has only content, as ISOSTS defines no attributes" do
+      it "IsoSts::#{klass} models content plus the conventional @id" do
         model = described_class.const_get(klass)
-        expect(model.attributes.keys).to eq(%i[content])
+        expect(model.attributes.keys).to eq(%i[content id])
       end
 
       it "IsoSts::#{klass} round-trips an empty <#{element}/>" do
@@ -497,32 +497,29 @@ RSpec.describe Sts::IsoSts do
     end
   end
 
-  # Attribute sets below are transcribed from ISOSTS.xsd. Round-tripping does
-  # not prove them: a model that invents or drops an attribute still parses and
-  # serialises symmetrically. Asserting the exact set is what catches that.
+  # Non-@id attribute sets below are transcribed from ISOSTS.xsd; the @id,
+  # where present, follows the 86948b9 convention. Round-tripping does not prove
+  # them: a model that invents or drops an attribute still parses and serialises
+  # symmetrically. Asserting the exact set is what catches that.
   describe "ISOSTS-modelled element classes" do
     {
-      Year: %i[content content_type specific_use xml_lang],
-      PubDate: %i[content pub_type],
+      Year: %i[content content_type specific_use xml_lang id],
+      PubDate: %i[content pub_type id],
       ReleaseVersionId: %i[content id],
       AltText: %i[content id content_type specific_use xml_lang],
       LongDesc: %i[content id content_type specific_use xml_lang],
       TexMath: %i[content id content_type notation version],
-      PubId: %i[content pub_id_type specific_use],
-      Volume: %i[content content_type seq specific_use xml_lang],
-      Issue: %i[content content_type seq specific_use xml_lang],
-      Fpage: %i[content content_type seq specific_use xml_lang],
-      Lpage: %i[content content_type specific_use xml_lang],
-      PageRange: %i[content content_type specific_use xml_lang],
+      PubId: %i[content pub_id_type specific_use id],
+      Volume: %i[content content_type seq specific_use xml_lang id],
+      Issue: %i[content content_type seq specific_use xml_lang id],
+      Fpage: %i[content content_type seq specific_use xml_lang id],
+      Lpage: %i[content content_type specific_use xml_lang id],
+      PageRange: %i[content content_type specific_use xml_lang id],
     }.each do |klass, expected|
-      it "IsoSts::#{klass} models exactly the ISOSTS attribute set" do
+      it "IsoSts::#{klass} models its configured attribute set" do
         expect(described_class.const_get(klass).attributes.keys)
           .to match_array(expected)
       end
-    end
-
-    it "IsoSts::Year has no id, which ISOSTS does not define" do
-      expect(described_class::Year.attributes).not_to have_key(:id)
     end
 
     it "IsoSts::Fpage carries seq but IsoSts::Lpage does not" do
@@ -535,8 +532,8 @@ RSpec.describe Sts::IsoSts do
       expect(described_class::Fpage.attributes).not_to have_key(:italic)
     end
 
-    it "IsoSts::IsProof is an empty element" do
-      expect(described_class::IsProof.attributes).to be_empty
+    it "IsoSts::IsProof carries only @id and has no content" do
+      expect(described_class::IsProof.attributes.keys).to eq(%i[id])
       round_tripped = described_class::IsProof
         .to_xml(described_class::IsProof.new).strip
       expect(round_tripped).to eq("<is-proof/>")
@@ -604,6 +601,31 @@ RSpec.describe Sts::IsoSts do
     it "is used by RegMeta rather than a plain string" do
       expect(described_class::RegMeta.attributes[:wi_number].type)
         .to eq(described_class::WiNumber)
+    end
+  end
+
+  # A model can declare `attribute :id` yet omit `map_attribute "id"`, which
+  # still satisfies the key-set assertions above while silently dropping @id on
+  # parse and omitting it on serialise. Every fixture is @id-free, so only an
+  # explicit round-trip proves the mapping exists.
+  describe "@id round-trips through parse and serialise" do
+    %i[
+      DocNumber DocType Fpage Ics IsProof Issue Lpage Originator PageRange
+      PartNumber ProjId PubDate PubId ReleaseVersion Sdo SupplNumber SupplType
+      SupplVersion Urn Version Volume Year Secretariat
+    ].each do |klass|
+      it "IsoSts::#{klass} preserves @id through a round-trip" do
+        model = described_class.const_get(klass)
+        element = model.mappings_for(:xml).root_element
+        xml = if klass == :IsProof
+                %(<#{element} id="x-1"/>)
+              else
+                %(<#{element} id="x-1">content</#{element}>)
+              end
+        parsed = model.from_xml(xml)
+        expect(parsed.id).to eq("x-1")
+        expect(model.to_xml(parsed)).to include('id="x-1"')
+      end
     end
   end
 end

--- a/spec/iso_sts/iso_sts_element_spec.rb
+++ b/spec/iso_sts/iso_sts_element_spec.rb
@@ -674,29 +674,46 @@ RSpec.describe Sts::IsoSts do
     end
   end
 
-  # The fixtures never carry these attributes, so a round-trip is the only proof
-  # the added mappings parse and serialise for their attribute shapes.
-  describe "ISOSTS attributes absent from fixtures still round-trip" do
-    it "IsoSts::CopyrightHolder preserves content-type" do
-      xml = %(<copyright-holder content-type="foo">ACME</copyright-holder>)
-      parsed = described_class::CopyrightHolder.from_xml(xml)
-      expect(parsed.content_type).to eq("foo")
-      expect(described_class::CopyrightHolder.to_xml(parsed))
-        .to include('content-type="foo"')
-    end
-
-    it "IsoSts::Label preserves alt" do
-      xml = %(<label alt="a">1</label>)
-      parsed = described_class::Label.from_xml(xml)
-      expect(parsed.alt).to eq("a")
-      expect(described_class::Label.to_xml(parsed)).to include('alt="a"')
-    end
-
-    it "IsoSts::Sub preserves arrange" do
-      xml = %(<sub arrange="stack">2</sub>)
-      parsed = described_class::Sub.from_xml(xml)
-      expect(parsed.arrange).to eq("stack")
-      expect(described_class::Sub.to_xml(parsed)).to include('arrange="stack"')
+  # Every attribute this change restored or remapped, proven to round-trip so a
+  # future edit cannot silently drop a mapping. The fixtures do not exercise
+  # most of these, so this is the only regression guard on the mappings. xlink
+  # attributes need xmlns:xlink for well-formed XML; xml:lang is predefined.
+  describe "restored ISOSTS attributes round-trip" do
+    {
+      Sub: %w[arrange specific-use],
+      Sup: %w[arrange specific-use],
+      ExtLink: %w[xlink:type xlink:role xlink:title xlink:show xlink:actuate],
+      MixedCitation: %w[xlink:type xlink:href xlink:role xlink:title xlink:show
+                        xlink:actuate],
+      CopyrightHolder: %w[content-type specific-use xml:lang],
+      CopyrightStatement: %w[content-type specific-use xml:lang],
+      CopyrightYear: %w[content-type specific-use],
+      Edition: %w[content-type specific-use xml:lang],
+      Title: %w[content-type specific-use],
+      Label: %w[alt xml:lang],
+      Uri: %w[xlink:type],
+      NamedContent: %w[xlink:type],
+      Graphic: %w[xlink:role xlink:title xlink:show xlink:actuate originator],
+      Underline: %w[underline-style],
+      Body: %w[specific-use],
+      Sec: %w[xml:lang],
+      Standard: %w[xml:lang],
+      TermSec: %w[xml:lang],
+    }.each do |klass, xml_attrs|
+      xml_attrs.each do |xml_attr|
+        it "IsoSts::#{klass} round-trips #{xml_attr}" do
+          model = described_class.const_get(klass)
+          element = model.mappings_for(:xml).root_element
+          ns = if xml_attr.start_with?("xlink:")
+                 ' xmlns:xlink="http://www.w3.org/1999/xlink"'
+               else
+                 ""
+               end
+          parsed = model.from_xml(%(<#{element}#{ns} #{xml_attr}="v-1"/>))
+          expect(parsed.public_send(xml_attr.tr(":-", "__"))).to eq("v-1")
+          expect(model.to_xml(parsed)).to include(%(#{xml_attr}="v-1"))
+        end
+      end
     end
   end
 

--- a/spec/iso_sts/iso_sts_element_spec.rb
+++ b/spec/iso_sts/iso_sts_element_spec.rb
@@ -643,7 +643,8 @@ RSpec.describe Sts::IsoSts do
     }.each do |klass, element|
       it "IsoSts::#{klass} preserves xlink:type through a round-trip" do
         model = described_class.const_get(klass)
-        xml = %(<#{element} xlink:type="simple">text</#{element}>)
+        ns = 'xmlns:xlink="http://www.w3.org/1999/xlink"'
+        xml = %(<#{element} #{ns} xlink:type="simple">text</#{element}>)
         parsed = model.from_xml(xml)
         expect(parsed.xlink_type).to eq("simple")
         expect(model.to_xml(parsed)).to include('xlink:type="simple"')

--- a/spec/iso_sts/iso_sts_element_spec.rb
+++ b/spec/iso_sts/iso_sts_element_spec.rb
@@ -428,10 +428,11 @@ RSpec.describe Sts::IsoSts do
     end
   end
 
-  # ISOSTS declares these elements as type="xs:string": text content, plus the
-  # conventional @id (86948b9). They are modelled as IsoSts classes rather than
-  # plain strings because an empty element (<sdo/>) does not survive a :string
-  # round-trip -- for a collection it parses to [], losing the element entirely.
+  # ISOSTS declares these elements as type="xs:string" (text content, no
+  # attributes). The @id they carry is the 86948b9 convention, not declared by
+  # ISOSTS. They are modelled as IsoSts classes, not plain strings, because an
+  # empty element (<sdo/>) does not survive a :string round-trip -- for a
+  # collection it parses to [], losing the element entirely.
   describe "ISOSTS xs:string elements" do
     {
       Originator: "originator",
@@ -625,6 +626,138 @@ RSpec.describe Sts::IsoSts do
         parsed = model.from_xml(xml)
         expect(parsed.id).to eq("x-1")
         expect(model.to_xml(parsed)).to include('id="x-1"')
+      end
+    end
+  end
+
+  # xlink:type is dropped on parse and omitted on serialise when unmapped. A
+  # round-trip on inline XML proves the mapping exists rather than merely
+  # asserting an accessor. These four models gained the xlink:type mapping in
+  # this change (ext-link/mixed-citation/uri also carry it in the fixtures).
+  describe "xlink:type round-trips through parse and serialise" do
+    {
+      ExtLink: "ext-link",
+      MixedCitation: "mixed-citation",
+      Uri: "uri",
+      NamedContent: "named-content",
+    }.each do |klass, element|
+      it "IsoSts::#{klass} preserves xlink:type through a round-trip" do
+        model = described_class.const_get(klass)
+        xml = %(<#{element} xlink:type="simple">text</#{element}>)
+        parsed = model.from_xml(xml)
+        expect(parsed.xlink_type).to eq("simple")
+        expect(model.to_xml(parsed)).to include('xlink:type="simple"')
+      end
+    end
+  end
+
+  # These three previously mapped ISOSTS xml:lang under the wrong XML name (bare
+  # lang), losing xml:lang on parse and emitting bare lang on serialise. This
+  # round-trip guards the corrected mapping; exact-set key assertions cannot,
+  # because all three expose :xml_lang either way.
+  describe "xml:lang round-trips through parse and serialise" do
+    {
+      Standard: "standard",
+      Sec: "sec",
+      TermSec: "term-sec",
+    }.each do |klass, element|
+      it "IsoSts::#{klass} preserves xml:lang and emits xml:lang not lang" do
+        model = described_class.const_get(klass)
+        xml = %(<#{element} xml:lang="en"/>)
+        parsed = model.from_xml(xml)
+        expect(parsed.xml_lang).to eq("en")
+        serialised = model.to_xml(parsed)
+        expect(serialised).to include('xml:lang="en"')
+        expect(serialised).not_to match(/\slang=/)
+      end
+    end
+  end
+
+  # The fixtures never carry these attributes, so a round-trip is the only proof
+  # the added mappings parse and serialise for their attribute shapes.
+  describe "ISOSTS attributes absent from fixtures still round-trip" do
+    it "IsoSts::CopyrightHolder preserves content-type" do
+      xml = %(<copyright-holder content-type="foo">ACME</copyright-holder>)
+      parsed = described_class::CopyrightHolder.from_xml(xml)
+      expect(parsed.content_type).to eq("foo")
+      expect(described_class::CopyrightHolder.to_xml(parsed))
+        .to include('content-type="foo"')
+    end
+
+    it "IsoSts::Label preserves alt" do
+      xml = %(<label alt="a">1</label>)
+      parsed = described_class::Label.from_xml(xml)
+      expect(parsed.alt).to eq("a")
+      expect(described_class::Label.to_xml(parsed)).to include('alt="a"')
+    end
+
+    it "IsoSts::Sub preserves arrange" do
+      xml = %(<sub arrange="stack">2</sub>)
+      parsed = described_class::Sub.from_xml(xml)
+      expect(parsed.arrange).to eq("stack")
+      expect(described_class::Sub.to_xml(parsed)).to include('arrange="stack"')
+    end
+  end
+
+  # Exact attribute-key sets after restoring the ISOSTS attributes these models
+  # silently dropped. Round-tripping cannot prove the set: a model that invents
+  # or drops an attribute still parses and serialises symmetrically. Asserting
+  # the exact set is what catches that.
+  describe "IsoSts element classes model their full ISOSTS attribute set" do
+    {
+      Sub: %i[id arrange specific_use content],
+      Sup: %i[id arrange specific_use content],
+      ExtLink: %i[
+        id ext_link_type specific_use xml_lang xlink_href xlink_type xlink_role
+        xlink_title xlink_show xlink_actuate content bold italic named_content
+      ],
+      MixedCitation: %i[
+        id publication_type publisher_type publication_format specific_use
+        xml_lang xlink_type xlink_href xlink_role xlink_title xlink_show
+        xlink_actuate content bold italic sub sup std ext_link uri named_content
+        styled_content fn xref break person_group collab year source
+        article_title volume issue fpage lpage page_range publisher pub_id
+      ],
+      CopyrightHolder: %i[
+        id content_type specific_use xml_lang content sub sup
+      ],
+      CopyrightStatement: %i[
+        id content_type specific_use xml_lang content bold italic ext_link uri
+      ],
+      CopyrightYear: %i[id content_type specific_use content],
+      Edition: %i[id content_type specific_use xml_lang content],
+      Title: %i[
+        id content_type specific_use content bold italic sub sup xref break
+        styled_content monospace sc inline_formula std
+      ],
+      Label: %i[
+        id alt xml_lang content bold italic sub sup inline_formula break
+        styled_content ext_link uri named_content
+      ],
+      Uri: %i[
+        content_type specific_use xml_lang xlink_href xlink_type xlink_role
+        xlink_title xlink_show xlink_actuate content
+      ],
+      NamedContent: %i[
+        id alt content_type specific_use xml_lang xlink_href xlink_type
+        xlink_role xlink_title xlink_show xlink_actuate content bold italic
+        sub sup
+      ],
+      Graphic: %i[
+        id position orientation specific_use xml_lang content_type mimetype
+        mime_subtype xlink_href xlink_type xlink_role xlink_title xlink_show
+        xlink_actuate graphic_type originator label caption alt_text long_desc
+      ],
+      Underline: %i[underline_style specific_use content bold italic sub sup],
+      Body: %i[
+        id content_type specific_use paragraph sec term_sec list def_list
+        disp_formula table_wrap fig non_normative_note non_normative_example
+        preformat styled_content array ref_list disp_quote editing_instruction
+      ],
+    }.each do |klass, expected|
+      it "IsoSts::#{klass} models its configured attribute set" do
+        expect(described_class.const_get(klass).attributes.keys)
+          .to match_array(expected)
       end
     end
   end


### PR DESCRIPTION
### Metanorma PR checklist

 - [x] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->

Restores the `@id` on 23 IsoSts element classes (the 86948b9 convention) and adds 39 ISOSTS attributes that 15 models silently dropped — real data loss, e.g. `sub`/`sup` `arrange`+`specific-use`, `ext-link`/`mixed-citation`/`uri`/`named-content` `xlink:*`, `graphic` `xlink:*`+`originator`, `copyright-*`, `edition`, `title`, `label`, `underline`, `body`. Also fixes `sec`/`standard`/`term-sec`, which mapped ISOSTS `xml:lang` under the wrong XML name (`lang`), losing it on parse.

**Breaking change:** `IsoSts::Standard#lang` is renamed to `#xml_lang` (to match its `Sec`/`TermSec` siblings and correct the `xml:lang` mapping). Callers using `standard.lang` must switch to `standard.xml_lang`.

Deferred to a follow-up: 7 spurious attributes on 5 models, and the 6 classes left without `@id` in 86948b9.
