### PR TITLE
chore: bump lutaml-model to ~> 0.8.18

### DIFF
--- a/sts.gemspec
+++ b/sts.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bigdecimal"
-  spec.add_dependency "lutaml-model", "~> 0.8.0"
+  spec.add_dependency "lutaml-model", "~> 0.8.18"
   spec.add_dependency "mml", "~> 2.4.0"
 
   # spec.add_dependency "thor"


### PR DESCRIPTION
## Summary

Bumps `lutaml-model` from `~> 0.8.0` to `~> 0.8.18`.

Picks up the fix for the `ordered` builder ignoring setter call order (lutaml/lutaml-model#735). Models that declare `xml do … ordered end` now serialise children in the order they were assigned on the instance, matching the documented behaviour. Previously they fell back to attribute declaration order, which broke `Sts::NisoSts::ListItem` and any other ordered-mode model that needs per-instance child ordering.

sts-ruby's test suite (2286 examples) is green on 0.8.18.

## Test plan

- [x] `bundle exec rspec` — 2286 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [ ] CI green on this PR
