### PR TITLE
fix: bind MathML version per host (V2 for IsoSts/TbxIsoTml, V3 for NisoSts)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,6 +70,7 @@ RSpec/DescribeClass:
     - 'spec/elements/new_elements_spec.rb'
     - 'spec/elements/reference_models_spec.rb'
     - 'spec/elements/structural_models_spec.rb'
+    - 'spec/mathml_version_spec.rb'
     - 'spec/round_trip/reference_docs_spec.rb'
 
 # Offense count: 1

--- a/lib/sts/iso_sts/disp_formula.rb
+++ b/lib/sts/iso_sts/disp_formula.rb
@@ -9,7 +9,7 @@ module Sts
       attribute :xml_lang, :string
       attribute :originator, :string
       attribute :label, ::Sts::IsoSts::Label
-      attribute :math, Mml::V3::Math
+      attribute :math, Mml::V2::Math
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :non_normative_note, ::Sts::IsoSts::NonNormativeNote

--- a/lib/sts/iso_sts/inline_formula.rb
+++ b/lib/sts/iso_sts/inline_formula.rb
@@ -7,7 +7,7 @@ module Sts
       attribute :content_type, :string
       attribute :specific_use, :string
       attribute :xml_lang, :string
-      attribute :math, Mml::V3::Math
+      attribute :math, Mml::V2::Math
       attribute :bold, ::Sts::IsoSts::Bold
       attribute :italic, ::Sts::IsoSts::Italic
       attribute :inline_formula, ::Sts::IsoSts::InlineFormula

--- a/lib/sts/iso_sts/paragraph.rb
+++ b/lib/sts/iso_sts/paragraph.rb
@@ -27,7 +27,7 @@ module Sts
       attribute :fn, ::Sts::TbxIsoTml::Fn, collection: true
       attribute :styled_content, ::Sts::IsoSts::StyledContent, collection: true
       attribute :graphic, ::Sts::IsoSts::Graphic, collection: true
-      attribute :math, Mml::V3::Math, collection: true
+      attribute :math, Mml::V2::Math, collection: true
       attribute :break, ::Sts::IsoSts::Break, collection: true
       attribute :sub, ::Sts::IsoSts::Sub, collection: true
       attribute :sup, ::Sts::IsoSts::Sup, collection: true

--- a/lib/sts/iso_sts/td.rb
+++ b/lib/sts/iso_sts/td.rb
@@ -23,7 +23,7 @@ module Sts
       attribute :disp_formula, ::Sts::IsoSts::DispFormula, collection: true
       attribute :list, ::Sts::IsoSts::List, collection: true
       attribute :def_list, ::Sts::IsoSts::DefList, collection: true
-      attribute :math, Mml::V3::Math, collection: true
+      attribute :math, Mml::V2::Math, collection: true
       attribute :std, ::Sts::IsoSts::Std, collection: true
       attribute :fn, ::Sts::TbxIsoTml::Fn, collection: true
       attribute :xref, ::Sts::TbxIsoTml::Xref, collection: true

--- a/lib/sts/iso_sts/term.rb
+++ b/lib/sts/iso_sts/term.rb
@@ -17,7 +17,7 @@ module Sts
       attribute :uri, ::Sts::IsoSts::Uri
       attribute :named_content, ::Sts::IsoSts::NamedContent
       attribute :styled_content, ::Sts::IsoSts::StyledContent
-      attribute :math, Mml::V3::Math
+      attribute :math, Mml::V2::Math
 
       xml do
         element "term"

--- a/lib/sts/iso_sts/th.rb
+++ b/lib/sts/iso_sts/th.rb
@@ -23,7 +23,7 @@ module Sts
       attribute :disp_formula, ::Sts::IsoSts::DispFormula, collection: true
       attribute :list, ::Sts::IsoSts::List, collection: true
       attribute :def_list, ::Sts::IsoSts::DefList, collection: true
-      attribute :math, Mml::V3::Math, collection: true
+      attribute :math, Mml::V2::Math, collection: true
       attribute :std, ::Sts::IsoSts::Std, collection: true
       attribute :fn, ::Sts::TbxIsoTml::Fn, collection: true
       attribute :xref, ::Sts::TbxIsoTml::Xref, collection: true

--- a/lib/sts/tbx_iso_tml/definition.rb
+++ b/lib/sts/tbx_iso_tml/definition.rb
@@ -8,7 +8,7 @@ module Sts
       attribute :note, ::Sts::TbxIsoTml::Note
       attribute :value, :string, collection: true
       attribute :italic, ::Sts::TbxIsoTml::Italic, collection: true
-      attribute :math, ::Mml::V3::Math
+      attribute :math, ::Mml::V2::Math
       attribute :sub, ::Sts::NisoSts::Sub, collection: true
       attribute :list, ::Sts::NisoSts::List, collection: true
       attribute :std, ::Sts::NisoSts::ReferenceStandard, collection: true

--- a/lib/sts/tbx_iso_tml/note.rb
+++ b/lib/sts/tbx_iso_tml/note.rb
@@ -7,7 +7,7 @@ module Sts
       attribute :value, :string, collection: true
       attribute :table_wrap, ::Sts::TbxIsoTml::TableWrap
       attribute :entailed_term, ::Sts::TbxIsoTml::EntailedTerm, collection: true
-      attribute :math, ::Mml::V3::Math, collection: true
+      attribute :math, ::Mml::V2::Math, collection: true
       attribute :xref, ::Sts::TbxIsoTml::Xref, collection: true
       attribute :list, ::Sts::NisoSts::List, collection: true
       attribute :std, ::Sts::NisoSts::ReferenceStandard, collection: true

--- a/lib/sts/tbx_iso_tml/term.rb
+++ b/lib/sts/tbx_iso_tml/term.rb
@@ -10,7 +10,7 @@ module Sts
       attribute :bold, ::Sts::TbxIsoTml::Bold, collection: true
       attribute :sub, ::Sts::NisoSts::Sub, collection: true
       attribute :sup, ::Sts::NisoSts::Sup, collection: true
-      attribute :math, ::Mml::V3::Math, collection: true
+      attribute :math, ::Mml::V2::Math, collection: true
       attribute :xref, ::Sts::TbxIsoTml::Xref, collection: true
       attribute :inline_formula, ::Sts::NisoSts::InlineFormula, collection: true
       attribute :std, ::Sts::NisoSts::ReferenceStandard, collection: true

--- a/spec/mathml_version_spec.rb
+++ b/spec/mathml_version_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# ISOSTS imports ncbi-mathml2 (reference-docs/isosts-v1/xsd/ncbi-mathml2/) and
+# uses the MathML 2 DTD (reference-docs/isosts-v1/mathml2.dtd). NISO STS uses
+# MathML 3 (reference-docs/NISO-STS-extended-1-MathML3-XSD/). TBX-in-ISOSTS is
+# the only TBX context used in this gem (no NisoSts reference to TBX math
+# elements), so TBX math-bearing elements also bind to V2.
+#
+# Round-tripping cannot prove this: a model that retypes math to V3 still
+# parses and serialises symmetrically. These specs assert the exact type so
+# future refactors that drift back to V3 fail loudly.
+RSpec.describe "MathML host version binding" do
+  describe Sts::IsoSts do
+    {
+      InlineFormula: :math,
+      DispFormula: :math,
+      Paragraph: :math,
+      Td: :math,
+      Th: :math,
+      Term: :math,
+    }.each do |model_name, attr|
+      it "##{model_name}##{attr} is Mml::V2::Math" do
+        klass = described_class.const_get(model_name)
+        expect(klass.attributes[attr].type).to eq(Mml::V2::Math)
+      end
+    end
+  end
+
+  describe Sts::TbxIsoTml do
+    {
+      Note: :math,
+      Term: :math,
+      Definition: :math,
+    }.each do |model_name, attr|
+      it "##{model_name}##{attr} is Mml::V2::Math" do
+        klass = described_class.const_get(model_name)
+        expect(klass.attributes[attr].type).to eq(Mml::V2::Math)
+      end
+    end
+  end
+
+  describe Sts::NisoSts do
+    {
+      InlineFormula: :math,
+      DisplayFormula: :math,
+    }.each do |model_name, attr|
+      it "##{model_name}##{attr} is Mml::V3::Math" do
+        klass = described_class.const_get(model_name)
+        expect(klass.attributes[attr].type).to eq(Mml::V3::Math)
+      end
+    end
+
+    {
+      "TbxIsoTml::Note" => "TBX-in-ISOSTS only",
+      "TbxIsoTml::Term" => "TBX-in-ISOSTS only",
+      "TbxIsoTml::Definition" => "TBX-in-ISOSTS only",
+    }.each do |class_ref, scope|
+      it "does not reference #{class_ref} (#{scope})" do
+        niso_sts_dir = File.expand_path("../lib/sts/niso_sts", __dir__)
+        grep_output = `grep -rl '#{class_ref}\\b' #{niso_sts_dir}`.strip
+        expect(grep_output).to be_empty,
+                               "NisoSts should not reference #{class_ref}; " \
+                               "found in: #{grep_output}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the schema-version bug introduced by `9e977a5 feat: unify MathML on mml gem across IsoSts, NisoSts, and TbxIsoTml`.

ISOSTS imports `ncbi-mathml2/mathml2.xsd` (MathML 2). NISO STS uses MathML 3. The unification commit retyped **every** math attribute to `Mml::V3::Math`, breaking ISOSTS schema conformance — an IsoSts document could now serialise MathML 3 elements that do not exist in MathML 2. Round-trip tests stayed green because a wrongly-typed model still parses and serialises symmetrically (the exact trap HassanAkbar's attribute-set specs were written to catch).

Re-bind per host:

| Namespace | MathML | Module |
|---|---|---|
| `Sts::IsoSts` | 2 (ISOSTS imports ncbi-mathml2) | `Mml::V2::Math` |
| `Sts::TbxIsoTml` | 2 (TBX-in-ISOSTS is the only TBX context here) | `Mml::V2::Math` |
| `Sts::NisoSts` | 3 (NISO STS schema) | `Mml::V3::Math` |

The "host-sensitive" choice collapses to static per-host binding because no `NisoSts::*` class references a TBX math-bearing element (verified by `grep` plus regression specs). If TBX-in-NISO-STS support is added later, that becomes a new TBX namespace variant, not a polymorphic attribute.

## Files changed

- `lib/sts/iso_sts/{td,inline_formula,paragraph,th,term,disp_formula}.rb` — `Mml::V3::Math` → `Mml::V2::Math` (6 files)
- `lib/sts/tbx_iso_tml/{note,term,definition}.rb` — `Mml::V3::Math` → `Mml::V2::Math` (3 files)
- `spec/mathml_version_spec.rb` (new) — asserts the exact type per attribute plus guards that NisoSts does not pull TBX math classes
- `.rubocop_todo.yml` — extend `RSpec/DescribeClass` Exclude (same convention as the other feature specs)

## Test plan

- [x] `bundle exec rspec` — 2300 examples, 0 failures (was 2286 + 14 new)
- [x] `bundle exec rubocop` — clean
- [ ] CI green on this PR
- [ ] Manual check: serialise an IsoSts document and confirm `<mml:math>` subtree is MathML 2-conformant (no V3-only elements/attrs)

## Notes

- This is a **behavior change** for callers that construct IsoSts documents from scratch with V3 Math — they must now pass `Mml::V2::Math` instances. No public API signature change.
- The `namespace_scope` workaround on `IsoSts::Standard` / `NisoSts::Standard` (listing both `MathmlNamespace` and `Mml::Namespace`) is unchanged — `Mml::V2::Math` uses the same `Mml::Namespace` class as V3 in its `xml do` block, so prefix preservation still works.
- The wider Content MathML unification (`lib/sts/niso_sts/mml_content/`) is out of scope here — that is a separate larger migration tracked in `isosts-uses-mathml2-not-mathml3` memory.
