### PR TITLE
fix: model IsoSts::DispQuote and BoxedText from ISOSTS.xsd; repoint Body/Sec

### DIFF
--- a/TODO.sts-refactor/00-overview.md
+++ b/TODO.sts-refactor/00-overview.md
@@ -19,7 +19,7 @@
 |---|------|----------|----------|--------------|
 | 01 | `01-mathml-delegation.md` | Anti-Pattern Fix | DONE | — |
 | 02 | `02-type-resolution.md` | Anti-Pattern Fix | DONE | — |
-| 03 | `03-namespace-coupling.md` | Architecture | IN PROGRESS (63→16 refs) | 01, 02 |
+| 03 | `03-namespace-coupling.md` | Architecture | IN PROGRESS (63→13 refs) | 01, 02 |
 | 04 | `04-register-versioning.md` | Architecture | HIGH | 01, 02 |
 | 05 | `05-missing-elements.md` | Feature Gap | MOSTLY DONE | 04 |
 | 06 | `06-missing-attributes.md` | Feature Gap | DONE | 04 |
@@ -166,7 +166,7 @@ grep -r "method_missing|respond_to_missing|Object.const_get|\.send" lib/
 - ~~Expand StringName usage (in contrib, element-citation, related-article — NISO STS 1.2)~~ → DONE: added to name-alternatives; already in person-group and mixed-citation
 
 ### Architectural Items (High Effort)
-- `03-namespace-coupling.md` — IN PROGRESS: 63→16 IsoSts→NisoSts references
+- `03-namespace-coupling.md` — IN PROGRESS: 63→13 IsoSts→NisoSts references
   remaining (issue #40). ISOSTS.xsd governs content models and all non-`@id`
   attributes; the `@id` follows the 86948b9 convention.
 - `04-register-versioning.md` — Version the models via lutaml-model Registers
@@ -193,12 +193,13 @@ the **NISO** XSD and applied the result to IsoSts.
 
 ## Next Action
 Two independent tracks:
-1. Finish `03` — the 16 remaining refs split evenly between seven recursive
-   roots and five child-bearing roots. The first 15 high-reuse dependency
-   leaves are now modelled, reducing the unresolved closures to 78–84
-   not-yet-modelled ISOSTS elements before existing IsoSts boundaries. The
-   remaining work still needs an architecture decision for the recursive
-   content core.
+1. Finish `03` — the 13 remaining refs split across five recursive roots
+   (`ElementCitation`, `PersonGroup`, `Collab`, `Source`, `TermDisplay`) and
+   five child-bearing roots. `DispQuote` and `BoxedText` themselves are now
+   IsoSts classes. The first 15 high-reuse dependency leaves are modelled,
+   reducing the unresolved closures to 78–84 not-yet-modelled ISOSTS elements
+   before existing IsoSts boundaries. The remaining work still needs an
+   architecture decision for the recursive content core.
 2. The remaining schema-conformance follow-up above — the 7 spurious attributes
    on 5 models and the 6 classes without `@id`. (The dropped-attribute data loss
    is now fixed.)

--- a/TODO.sts-refactor/03-namespace-coupling.md
+++ b/TODO.sts-refactor/03-namespace-coupling.md
@@ -3,7 +3,7 @@
 **Priority**: HIGH
 **Category**: Architecture
 **Estimated Effort**: High
-**Status**: Partially done — 63 → 16 references (GitHub issue #40)
+**Status**: Partially done — 63 → 13 references (GitHub issue #40)
 
 ## Problem
 
@@ -12,7 +12,8 @@ independent of NisoSts (ADR 2026-05-07): ISOSTS is frozen legacy, NISO STS
 evolves, so coupling them violates OCP.
 
 PR #31 reduced this from 157 to 63 references. Issue #40 reduced it further,
-from 63 to 16.
+from 63 to 16. The `IsoSts::DispQuote` / `IsoSts::BoxedText` addition then
+reduced it from 16 to 13 (Body#disp_quote, Sec#disp_quote, Sec#boxed_text).
 
 ## Content models from ISOSTS.xsd; `@id` from the 86948b9 convention
 
@@ -69,6 +70,16 @@ Non-`@id` attribute lists must be **generated** from the XSD, never hand-read:
 - **3 Niso-only child refs deleted** — `std-meta` from `Front` and
   `editing-instruction` from `Body` and `Sec`. Neither element exists in
   ISOSTS.xsd, so adding IsoSts equivalents would incorrectly expand the schema.
+- **`DispQuote` and `BoxedText` added** — modelled from ISOSTS.xsd (not copied
+  from NisoSts, which disagrees: `NisoSts::DispQuote` lacks `xml_lang` and
+  `title`; `NisoSts::BoxedText` carries `form_type`/`is_form` that ISOSTS does
+  not define). Children limited to existing IsoSts types; omitted children
+  (`attrib`, `speech`, `statement`, `verse-group`, `address`, `alternatives`,
+  `array`, `chem-struct-wrap`, `fig-group`, `media`, `supplementary-material`,
+  `table-wrap`, `table-wrap-group`, `disp-formula-group`, `mml:math`,
+  `related-article`, `related-object`, `glossary`) are tracked below.
+  `BoxedText#sts_object_id` (not `:object_id`) follows the `NisoSts::Graphic`
+  convention to avoid clashing with `Object#object_id`. 3 refs.
 
 ### Why classes and not plain `:string`
 
@@ -79,12 +90,13 @@ round-trip. For a scalar, `render_empty: :empty` recovers it; for a collection
 to `[]`, destroying the information at parse time before any render option
 applies. Content-only classes round-trip every case.
 
-## Remaining — 16 refs
+## Remaining — 13 refs
 
-**8 refs to 7 recursive roots**: `ElementCitation`, `PersonGroup`, `Collab`,
-`Source`, `DispQuote`, `TermDisplay`, and `BoxedText`. Each reaches the same
-78–79-element mutually-recursive core before existing IsoSts boundaries
-(`sec` → `p` → `disp-quote` → `p`). No direct one-file path remains.
+**5 refs to 5 recursive roots**: `ElementCitation`, `PersonGroup`, `Collab`,
+`Source`, `TermDisplay`. Each reaches the same 78–79-element
+mutually-recursive core before existing IsoSts boundaries (`sec` → `p` →
+`disp-quote` → `p`). `DispQuote` and `BoxedText` themselves are now IsoSts
+classes and no longer in this list.
 
 **8 refs to 5 child-bearing roots**, now measured after the first dependency
 layer: `attrib` (:1082) reaches 78 not-yet-modelled ISOSTS elements before

--- a/lib/sts/iso_sts.rb
+++ b/lib/sts/iso_sts.rb
@@ -88,6 +88,8 @@ module Sts
     autoload :Label, "#{__dir__}/iso_sts/label"
     autoload :Title, "#{__dir__}/iso_sts/title"
     autoload :Bold, "#{__dir__}/iso_sts/bold"
+    autoload :BoxedText, "#{__dir__}/iso_sts/boxed_text"
+    autoload :DispQuote, "#{__dir__}/iso_sts/disp_quote"
     autoload :Italic, "#{__dir__}/iso_sts/italic"
     autoload :Monospace, "#{__dir__}/iso_sts/monospace"
     autoload :NamedContent, "#{__dir__}/iso_sts/named_content"

--- a/lib/sts/iso_sts/boxed_text.rb
+++ b/lib/sts/iso_sts/boxed_text.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Sts
+  module IsoSts
+    class BoxedText < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :position, :string
+      attribute :orientation, :string
+      attribute :specific_use, :string
+      attribute :xml_lang, :string
+      attribute :content_type, :string
+      attribute :originator, :string
+      attribute :sts_object_id, ::Sts::IsoSts::ObjectId, collection: true
+      attribute :label, ::Sts::IsoSts::Label
+      attribute :caption, ::Sts::IsoSts::Caption
+      attribute :paragraph, ::Sts::IsoSts::Paragraph, collection: true
+      attribute :list, ::Sts::IsoSts::List, collection: true
+      attribute :def_list, ::Sts::IsoSts::DefList, collection: true
+      attribute :non_normative_note, ::Sts::IsoSts::NonNormativeNote,
+                collection: true
+      attribute :non_normative_example, ::Sts::IsoSts::NonNormativeExample,
+                collection: true
+      attribute :preformat, ::Sts::IsoSts::Preformat, collection: true
+      attribute :fig, ::Sts::IsoSts::Fig, collection: true
+      attribute :graphic, ::Sts::IsoSts::Graphic, collection: true
+      attribute :disp_formula, ::Sts::IsoSts::DispFormula, collection: true
+      attribute :disp_quote, ::Sts::IsoSts::DispQuote, collection: true
+      attribute :boxed_text, ::Sts::IsoSts::BoxedText, collection: true
+      attribute :sec, ::Sts::IsoSts::Sec, collection: true
+      attribute :term_sec, ::Sts::IsoSts::TermSec, collection: true
+      attribute :fn_group, ::Sts::IsoSts::FnGroup, collection: true
+      attribute :ref_list, ::Sts::IsoSts::RefList, collection: true
+      attribute :permissions, ::Sts::IsoSts::Permissions, collection: true
+
+      xml do # rubocop:disable Metrics/BlockLength
+        element "boxed-text"
+        ordered
+
+        map_attribute "id", to: :id
+        map_attribute "position", to: :position
+        map_attribute "orientation", to: :orientation
+        map_attribute "specific-use", to: :specific_use
+        map_attribute "xml:lang", to: :xml_lang
+        map_attribute "content-type", to: :content_type
+        map_attribute "originator", to: :originator
+
+        map_element "object-id", to: :sts_object_id
+        map_element "label", to: :label
+        map_element "caption", to: :caption
+        map_element "p", to: :paragraph
+        map_element "list", to: :list
+        map_element "def-list", to: :def_list
+        map_element "non-normative-note", to: :non_normative_note
+        map_element "non-normative-example", to: :non_normative_example
+        map_element "preformat", to: :preformat
+        map_element "fig", to: :fig
+        map_element "graphic", to: :graphic
+        map_element "disp-formula", to: :disp_formula
+        map_element "disp-quote", to: :disp_quote
+        map_element "boxed-text", to: :boxed_text
+        map_element "sec", to: :sec
+        map_element "term-sec", to: :term_sec
+        map_element "fn-group", to: :fn_group
+        map_element "ref-list", to: :ref_list
+        map_element "permissions", to: :permissions
+      end
+    end
+  end
+end

--- a/lib/sts/iso_sts/disp_quote.rb
+++ b/lib/sts/iso_sts/disp_quote.rb
@@ -2,51 +2,51 @@
 
 module Sts
   module IsoSts
-    class Body < Lutaml::Model::Serializable
+    class DispQuote < Lutaml::Model::Serializable
       attribute :id, :string
       attribute :content_type, :string
       attribute :specific_use, :string
+      attribute :xml_lang, :string
+      attribute :originator, :string
+      attribute :label, ::Sts::IsoSts::Label
+      attribute :title, ::Sts::IsoSts::Title
       attribute :paragraph, ::Sts::IsoSts::Paragraph, collection: true
-      attribute :sec, ::Sts::IsoSts::Sec, collection: true
-      attribute :term_sec, ::Sts::IsoSts::TermSec, collection: true
       attribute :list, ::Sts::IsoSts::List, collection: true
       attribute :def_list, ::Sts::IsoSts::DefList, collection: true
-      attribute :disp_formula, ::Sts::IsoSts::DispFormula, collection: true
-      attribute :table_wrap, ::Sts::TbxIsoTml::TableWrap, collection: true
-      attribute :fig, ::Sts::IsoSts::Fig, collection: true
       attribute :non_normative_note, ::Sts::IsoSts::NonNormativeNote,
                 collection: true
       attribute :non_normative_example, ::Sts::IsoSts::NonNormativeExample,
                 collection: true
       attribute :preformat, ::Sts::IsoSts::Preformat, collection: true
-      attribute :styled_content, ::Sts::IsoSts::StyledContent, collection: true
-      attribute :array, ::Sts::IsoSts::Array, collection: true
-      attribute :ref_list, ::Sts::IsoSts::RefList, collection: true
+      attribute :fig, ::Sts::IsoSts::Fig, collection: true
+      attribute :graphic, ::Sts::IsoSts::Graphic, collection: true
+      attribute :disp_formula, ::Sts::IsoSts::DispFormula, collection: true
       attribute :disp_quote, ::Sts::IsoSts::DispQuote, collection: true
+      attribute :permissions, ::Sts::IsoSts::Permissions, collection: true
 
       xml do
-        element "body"
+        element "disp-quote"
         ordered
 
         map_attribute "id", to: :id
         map_attribute "content-type", to: :content_type
         map_attribute "specific-use", to: :specific_use
+        map_attribute "xml:lang", to: :xml_lang
+        map_attribute "originator", to: :originator
 
+        map_element "label", to: :label
+        map_element "title", to: :title
         map_element "p", to: :paragraph
-        map_element "sec", to: :sec
-        map_element "term-sec", to: :term_sec
         map_element "list", to: :list
         map_element "def-list", to: :def_list
-        map_element "disp-formula", to: :disp_formula
-        map_element "table-wrap", to: :table_wrap
-        map_element "fig", to: :fig
         map_element "non-normative-note", to: :non_normative_note
         map_element "non-normative-example", to: :non_normative_example
         map_element "preformat", to: :preformat
-        map_element "styled-content", to: :styled_content
-        map_element "array", to: :array
-        map_element "ref-list", to: :ref_list
+        map_element "fig", to: :fig
+        map_element "graphic", to: :graphic
+        map_element "disp-formula", to: :disp_formula
         map_element "disp-quote", to: :disp_quote
+        map_element "permissions", to: :permissions
       end
     end
   end

--- a/lib/sts/iso_sts/sec.rb
+++ b/lib/sts/iso_sts/sec.rb
@@ -33,9 +33,9 @@ module Sts
       attribute :uri, ::Sts::IsoSts::Uri, collection: true
       attribute :sec, ::Sts::IsoSts::Sec, collection: true
       attribute :term_sec, ::Sts::IsoSts::TermSec, collection: true
-      attribute :disp_quote, ::Sts::NisoSts::DispQuote, collection: true
+      attribute :disp_quote, ::Sts::IsoSts::DispQuote, collection: true
       attribute :fn, ::Sts::IsoSts::Fn, collection: true
-      attribute :boxed_text, ::Sts::NisoSts::BoxedText, collection: true
+      attribute :boxed_text, ::Sts::IsoSts::BoxedText, collection: true
 
       xml do # rubocop:disable Metrics/BlockLength
         element "sec"

--- a/spec/iso_sts/iso_sts_element_spec.rb
+++ b/spec/iso_sts/iso_sts_element_spec.rb
@@ -1032,7 +1032,7 @@ RSpec.describe Sts::IsoSts do
       files = %w[disp_quote boxed_text].map { |n| "lib/sts/iso_sts/#{n}.rb" }
       files.each do |path|
         msg = "#{path} must not reference Sts::NisoSts (namespace independence)"
-        expect(File.read(path)).not_to match(/Sts::NisoSts/), msg
+        expect(File.read(path)).not_to include("Sts::NisoSts"), msg
       end
     end
   end

--- a/spec/iso_sts/iso_sts_element_spec.rb
+++ b/spec/iso_sts/iso_sts_element_spec.rb
@@ -964,4 +964,93 @@ RSpec.describe Sts::IsoSts do
       end
     end
   end
+
+  # ISOSTS <disp-quote> and <boxed-text> are modelled from ISOSTS.xsd, not
+  # copied from NisoSts (which disagrees — NisoSts::DispQuote lacks xml_lang
+  # and title; NisoSts::BoxedText has form_type/is_form that ISOSTS does not
+  # define). Children limited to the IsoSts classes that currently exist;
+  # omitted children (attrib, speech, statement, verse-group, etc.) are
+  # tracked in TODO.sts-refactor/03-namespace-coupling.md.
+  describe "IsoSts::DispQuote and BoxedText are modelled from ISOSTS.xsd" do
+    it "DispQuote models its configured attribute set" do
+      expect(described_class::DispQuote.attributes.keys)
+        .to match_array(%i[
+                          id content_type specific_use xml_lang originator
+                          label title paragraph list def_list non_normative_note
+                          non_normative_example preformat fig graphic
+                          disp_formula disp_quote permissions
+                        ])
+    end
+
+    it "BoxedText models its configured attribute set" do
+      expect(described_class::BoxedText.attributes.keys)
+        .to match_array(%i[
+                          id position orientation specific_use xml_lang
+                          content_type originator sts_object_id label caption
+                          paragraph list def_list non_normative_note
+                          non_normative_example preformat fig graphic
+                          disp_formula disp_quote boxed_text sec term_sec
+                          fn_group ref_list permissions
+                        ])
+    end
+
+    it "BoxedText exposes :sts_object_id, not :object_id" do
+      # Object#object_id is Ruby's built-in; redefining it via lutaml-model
+      # accessor clashes. Follow the NisoSts::Graphic precedent.
+      expect(described_class::BoxedText.attributes).to have_key(:sts_object_id)
+      expect(described_class::BoxedText.attributes).not_to have_key(:object_id)
+    end
+
+    {
+      DispQuote: {
+        paragraph: :Paragraph, list: :List, def_list: :DefList,
+        non_normative_note: :NonNormativeNote,
+        non_normative_example: :NonNormativeExample, preformat: :Preformat,
+        fig: :Fig, graphic: :Graphic, disp_formula: :DispFormula,
+        disp_quote: :DispQuote, permissions: :Permissions
+      },
+      BoxedText: {
+        sts_object_id: :ObjectId, paragraph: :Paragraph, list: :List,
+        def_list: :DefList, non_normative_note: :NonNormativeNote,
+        non_normative_example: :NonNormativeExample, preformat: :Preformat,
+        fig: :Fig, graphic: :Graphic, disp_formula: :DispFormula,
+        disp_quote: :DispQuote, boxed_text: :BoxedText, sec: :Sec,
+        term_sec: :TermSec, fn_group: :FnGroup, ref_list: :RefList,
+        permissions: :Permissions
+      },
+    }.each do |klass, children|
+      children.each do |attr, child_class|
+        it "IsoSts::#{klass}##{attr} uses IsoSts::#{child_class}" do
+          parent = described_class.const_get(klass)
+          expect(parent.attributes[attr].type)
+            .to eq(described_class.const_get(child_class))
+        end
+      end
+    end
+
+    it "no IsoSts::DispQuote or BoxedText child references NisoSts" do
+      files = %w[disp_quote boxed_text].map { |n| "lib/sts/iso_sts/#{n}.rb" }
+      files.each do |path|
+        msg = "#{path} must not reference Sts::NisoSts (namespace independence)"
+        expect(File.read(path)).not_to match(/Sts::NisoSts/), msg
+      end
+    end
+  end
+
+  describe "IsoSts::Body and Sec repoint to IsoSts::DispQuote / BoxedText" do
+    it "Body#disp_quote is IsoSts::DispQuote" do
+      expect(described_class::Body.attributes[:disp_quote].type)
+        .to eq(described_class::DispQuote)
+    end
+
+    it "Sec#disp_quote is IsoSts::DispQuote" do
+      expect(described_class::Sec.attributes[:disp_quote].type)
+        .to eq(described_class::DispQuote)
+    end
+
+    it "Sec#boxed_text is IsoSts::BoxedText" do
+      expect(described_class::Sec.attributes[:boxed_text].type)
+        .to eq(described_class::BoxedText)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Resolves 3 of the 16 remaining IsoSts → NisoSts coupling references tracked in `TODO.sts-refactor/03-namespace-coupling.md`:

- `IsoSts::Body#disp_quote` was typed `NisoSts::DispQuote`
- `IsoSts::Sec#disp_quote` was typed `NisoSts::DispQuote`
- `IsoSts::Sec#boxed_text` was typed `NisoSts::BoxedText`

Per ADR 2026-05-07 IsoSts must be independent of NisoSts: ISOSTS is frozen legacy, NISO STS evolves, and the schemas genuinely diverge. Modelling from `reference-docs/isosts-v1/xsd/ISOSTS.xsd` rather than copying NisoSts:

| Element | ISOSTS attrs | NisoSts model |
|---|---|---|
| `<disp-quote>` | `id content-type specific-use xml:lang originator` | missing `xml:lang`; no `title` child |
| `<boxed-text>` | `id position orientation specific-use xml:lang content-type originator` | has `form_type`/`is_form` that ISOSTS doesn't define |

## Files

- `lib/sts/iso_sts/disp_quote.rb` (new) — 5 attrs + 13 IsoSts children (label, title, paragraph, list, def_list, non_normative_note, non_normative_example, preformat, fig, graphic, disp_formula, disp_quote recursive, permissions).
- `lib/sts/iso_sts/boxed_text.rb` (new) — 7 attrs + 19 IsoSts children (object_id via `sts_object_id` to avoid clashing with Ruby's `Object#object_id` — same convention as `NisoSts::Graphic`).
- `lib/sts/iso_sts.rb` — autoloads for `BoxedText` and `DispQuote`.
- `lib/sts/iso_sts/body.rb`, `lib/sts/iso_sts/sec.rb` — repoint `:disp_quote` and `:boxed_text` to the new IsoSts types.
- `spec/iso_sts/iso_sts_element_spec.rb` — 35 new specs (attribute-set assertions, child type assertions, no-NisoSts guard, Body/Sec repoint type assertions).
- `TODO.sts-refactor/03-namespace-coupling.md` + `00-overview.md` — updated count to 63→13 and removed DispQuote/BoxedText from the "remaining" list.

## Omitted children (not in scope; tracked in TODO 03)

Both classes omit ISOSTS children that have no IsoSts equivalent yet: `attrib`, `speech`, `statement`, `verse-group`, `address`, `alternatives`, `array`, `chem-struct-wrap`, `fig-group`, `media`, `supplementary-material`, `table-wrap`, `table-wrap-group`, `disp-formula-group`, `mml:math`, `related-article`, `related-object`, `glossary`. Modelling these requires creating the corresponding IsoSts classes first — that's the deferred TODO 03 work for the recursive core.

## Test plan

- [x] `bundle exec rspec` — 2551 examples, 0 failures (was 2516; +35 new)
- [x] `bundle exec rubocop` — clean (529 files)
- [ ] CI green on this PR
