### PR TITLE
feat: model IsoSts::Attrib from ISOSTS.xsd; fill PR #48 gap in DispQuote/BoxedText

### DIFF
--- a/TODO.sts-refactor/00-overview.md
+++ b/TODO.sts-refactor/00-overview.md
@@ -19,7 +19,7 @@
 |---|------|----------|----------|--------------|
 | 01 | `01-mathml-delegation.md` | Anti-Pattern Fix | DONE | — |
 | 02 | `02-type-resolution.md` | Anti-Pattern Fix | DONE | — |
-| 03 | `03-namespace-coupling.md` | Architecture | IN PROGRESS (63→13 refs) | 01, 02 |
+| 03 | `03-namespace-coupling.md` | Architecture | IN PROGRESS (63→11 refs) | 01, 02 |
 | 04 | `04-register-versioning.md` | Architecture | HIGH | 01, 02 |
 | 05 | `05-missing-elements.md` | Feature Gap | MOSTLY DONE | 04 |
 | 06 | `06-missing-attributes.md` | Feature Gap | DONE | 04 |
@@ -166,7 +166,7 @@ grep -r "method_missing|respond_to_missing|Object.const_get|\.send" lib/
 - ~~Expand StringName usage (in contrib, element-citation, related-article — NISO STS 1.2)~~ → DONE: added to name-alternatives; already in person-group and mixed-citation
 
 ### Architectural Items (High Effort)
-- `03-namespace-coupling.md` — IN PROGRESS: 63→13 IsoSts→NisoSts references
+- `03-namespace-coupling.md` — IN PROGRESS: 63→11 IsoSts→NisoSts references
   remaining (issue #40). ISOSTS.xsd governs content models and all non-`@id`
   attributes; the `@id` follows the 86948b9 convention.
 - `04-register-versioning.md` — Version the models via lutaml-model Registers
@@ -193,7 +193,7 @@ the **NISO** XSD and applied the result to IsoSts.
 
 ## Next Action
 Two independent tracks:
-1. Finish `03` — the 13 remaining refs split across five recursive roots
+1. Finish `03` — the 11 remaining refs split across five recursive roots
    (`ElementCitation`, `PersonGroup`, `Collab`, `Source`, `TermDisplay`) and
    five child-bearing roots. `DispQuote` and `BoxedText` themselves are now
    IsoSts classes. The first 15 high-reuse dependency leaves are modelled,

--- a/TODO.sts-refactor/03-namespace-coupling.md
+++ b/TODO.sts-refactor/03-namespace-coupling.md
@@ -3,7 +3,7 @@
 **Priority**: HIGH
 **Category**: Architecture
 **Estimated Effort**: High
-**Status**: Partially done — 63 → 13 references (GitHub issue #40)
+**Status**: Partially done — 63 → 11 references (GitHub issue #40)
 
 ## Problem
 
@@ -14,6 +14,9 @@ evolves, so coupling them violates OCP.
 PR #31 reduced this from 157 to 63 references. Issue #40 reduced it further,
 from 63 to 16. The `IsoSts::DispQuote` / `IsoSts::BoxedText` addition then
 reduced it from 16 to 13 (Body#disp_quote, Sec#disp_quote, Sec#boxed_text).
+The `IsoSts::Attrib` addition then reduced it from 13 to 11
+(Array#attrib, TableWrapFoot#attrib) and filled the omission in DispQuote /
+BoxedText from PR #48.
 
 ## Content models from ISOSTS.xsd; `@id` from the 86948b9 convention
 
@@ -74,12 +77,20 @@ Non-`@id` attribute lists must be **generated** from the XSD, never hand-read:
   from NisoSts, which disagrees: `NisoSts::DispQuote` lacks `xml_lang` and
   `title`; `NisoSts::BoxedText` carries `form_type`/`is_form` that ISOSTS does
   not define). Children limited to existing IsoSts types; omitted children
-  (`attrib`, `speech`, `statement`, `verse-group`, `address`, `alternatives`,
+  (`speech`, `statement`, `verse-group`, `address`, `alternatives`,
   `array`, `chem-struct-wrap`, `fig-group`, `media`, `supplementary-material`,
   `table-wrap`, `table-wrap-group`, `disp-formula-group`, `mml:math`,
   `related-article`, `related-object`, `glossary`) are tracked below.
   `BoxedText#sts_object_id` (not `:object_id`) follows the `NisoSts::Graphic`
   convention to avoid clashing with `Object#object_id`. 3 refs.
+- **`Attrib` added** — mixed-content class modelled from ISOSTS.xsd with the
+  25 inline-element children that have IsoSts types today. Fills the
+  `attrib` gap left in `DispQuote` and `BoxedText` from the prior bullet.
+  2 refs (`Array#attrib`, `TableWrapFoot#attrib`). Omitted inline children
+  (`inline-supplementary-material`, `related-article`, `related-object`,
+  `element-citation`, `overline`, `roman`, `sans-serif`, `alternatives`,
+  `private-char`, `chem-struct`, `mml:math`, `target`, `tbx:entailedTerm`)
+  tracked below.
 
 ### Why classes and not plain `:string`
 
@@ -90,12 +101,12 @@ round-trip. For a scalar, `render_empty: :empty` recovers it; for a collection
 to `[]`, destroying the information at parse time before any render option
 applies. Content-only classes round-trip every case.
 
-## Remaining — 13 refs
+## Remaining — 11 refs
 
 **5 refs to 5 recursive roots**: `ElementCitation`, `PersonGroup`, `Collab`,
 `Source`, `TermDisplay`. Each reaches the same 78–79-element
 mutually-recursive core before existing IsoSts boundaries (`sec` → `p` →
-`disp-quote` → `p`). `DispQuote` and `BoxedText` themselves are now IsoSts
+`disp-quote` → `p`). `DispQuote`, `BoxedText`, and `Attrib` are now IsoSts
 classes and no longer in this list.
 
 **8 refs to 5 child-bearing roots**, now measured after the first dependency

--- a/lib/sts/iso_sts.rb
+++ b/lib/sts/iso_sts.rb
@@ -101,6 +101,7 @@ module Sts
     # Shared model foundations
     autoload :Abbrev, "#{__dir__}/iso_sts/abbrev"
     autoload :Annotation, "#{__dir__}/iso_sts/annotation"
+    autoload :Attrib, "#{__dir__}/iso_sts/attrib"
     autoload :Country, "#{__dir__}/iso_sts/country"
     autoload :Day, "#{__dir__}/iso_sts/day"
     autoload :Etal, "#{__dir__}/iso_sts/etal"

--- a/lib/sts/iso_sts/array.rb
+++ b/lib/sts/iso_sts/array.rb
@@ -11,7 +11,7 @@ module Sts
       attribute :originator, :string
       attribute :label, ::Sts::IsoSts::Label
       attribute :table, ::Sts::IsoSts::Table
-      attribute :attrib, ::Sts::NisoSts::Attrib, collection: true
+      attribute :attrib, ::Sts::IsoSts::Attrib, collection: true
       attribute :permissions, ::Sts::IsoSts::Permissions, collection: true
 
       xml do

--- a/lib/sts/iso_sts/attrib.rb
+++ b/lib/sts/iso_sts/attrib.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Sts
+  module IsoSts
+    class Attrib < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :specific_use, :string
+      attribute :xml_lang, :string
+      attribute :content, :string, collection: true
+      attribute :email, ::Sts::IsoSts::Email, collection: true
+      attribute :ext_link, ::Sts::IsoSts::ExtLink, collection: true
+      attribute :uri, ::Sts::IsoSts::Uri, collection: true
+      attribute :mixed_citation, ::Sts::IsoSts::MixedCitation, collection: true
+      attribute :std, ::Sts::IsoSts::Std, collection: true
+      attribute :bold, ::Sts::IsoSts::Bold, collection: true
+      attribute :italic, ::Sts::IsoSts::Italic, collection: true
+      attribute :monospace, ::Sts::IsoSts::Monospace, collection: true
+      attribute :num, ::Sts::IsoSts::Num, collection: true
+      attribute :sc, ::Sts::IsoSts::Sc, collection: true
+      attribute :strike, ::Sts::IsoSts::Strike, collection: true
+      attribute :underline, ::Sts::IsoSts::Underline, collection: true
+      attribute :inline_graphic, ::Sts::IsoSts::InlineGraphic, collection: true
+      attribute :inline_formula, ::Sts::IsoSts::InlineFormula, collection: true
+      attribute :abbrev, ::Sts::IsoSts::Abbrev, collection: true
+      attribute :milestone_end, ::Sts::IsoSts::MilestoneEnd, collection: true
+      attribute :milestone_start, ::Sts::IsoSts::MilestoneStart,
+                collection: true
+      attribute :named_content, ::Sts::IsoSts::NamedContent, collection: true
+      attribute :styled_content, ::Sts::IsoSts::StyledContent, collection: true
+      attribute :fn, ::Sts::IsoSts::Fn, collection: true
+      attribute :xref, ::Sts::IsoSts::Xref, collection: true
+      attribute :std_ref, ::Sts::IsoSts::StdRef, collection: true
+      attribute :sub, ::Sts::IsoSts::Sub, collection: true
+      attribute :sup, ::Sts::IsoSts::Sup, collection: true
+
+      xml do # rubocop:disable Metrics/BlockLength
+        element "attrib"
+        mixed_content
+
+        map_attribute "id", to: :id
+        map_attribute "specific-use", to: :specific_use
+        map_attribute "xml:lang", to: :xml_lang
+
+        map_content to: :content
+        map_element "email", to: :email
+        map_element "ext-link", to: :ext_link
+        map_element "uri", to: :uri
+        map_element "mixed-citation", to: :mixed_citation
+        map_element "std", to: :std
+        map_element "bold", to: :bold
+        map_element "italic", to: :italic
+        map_element "monospace", to: :monospace
+        map_element "num", to: :num
+        map_element "sc", to: :sc
+        map_element "strike", to: :strike
+        map_element "underline", to: :underline
+        map_element "inline-graphic", to: :inline_graphic
+        map_element "inline-formula", to: :inline_formula
+        map_element "abbrev", to: :abbrev
+        map_element "milestone-end", to: :milestone_end
+        map_element "milestone-start", to: :milestone_start
+        map_element "named-content", to: :named_content
+        map_element "styled-content", to: :styled_content
+        map_element "fn", to: :fn
+        map_element "xref", to: :xref
+        map_element "std-ref", to: :std_ref
+        map_element "sub", to: :sub
+        map_element "sup", to: :sup
+      end
+    end
+  end
+end

--- a/lib/sts/iso_sts/boxed_text.rb
+++ b/lib/sts/iso_sts/boxed_text.rb
@@ -30,6 +30,7 @@ module Sts
       attribute :term_sec, ::Sts::IsoSts::TermSec, collection: true
       attribute :fn_group, ::Sts::IsoSts::FnGroup, collection: true
       attribute :ref_list, ::Sts::IsoSts::RefList, collection: true
+      attribute :attrib, ::Sts::IsoSts::Attrib, collection: true
       attribute :permissions, ::Sts::IsoSts::Permissions, collection: true
 
       xml do # rubocop:disable Metrics/BlockLength
@@ -62,6 +63,7 @@ module Sts
         map_element "term-sec", to: :term_sec
         map_element "fn-group", to: :fn_group
         map_element "ref-list", to: :ref_list
+        map_element "attrib", to: :attrib
         map_element "permissions", to: :permissions
       end
     end

--- a/lib/sts/iso_sts/disp_quote.rb
+++ b/lib/sts/iso_sts/disp_quote.rb
@@ -22,6 +22,7 @@ module Sts
       attribute :graphic, ::Sts::IsoSts::Graphic, collection: true
       attribute :disp_formula, ::Sts::IsoSts::DispFormula, collection: true
       attribute :disp_quote, ::Sts::IsoSts::DispQuote, collection: true
+      attribute :attrib, ::Sts::IsoSts::Attrib, collection: true
       attribute :permissions, ::Sts::IsoSts::Permissions, collection: true
 
       xml do
@@ -46,6 +47,7 @@ module Sts
         map_element "graphic", to: :graphic
         map_element "disp-formula", to: :disp_formula
         map_element "disp-quote", to: :disp_quote
+        map_element "attrib", to: :attrib
         map_element "permissions", to: :permissions
       end
     end

--- a/lib/sts/iso_sts/table_wrap_foot.rb
+++ b/lib/sts/iso_sts/table_wrap_foot.rb
@@ -10,7 +10,7 @@ module Sts
       attribute :non_normative_example, ::Sts::IsoSts::NonNormativeExample
       attribute :fn_group, ::Sts::IsoSts::FnGroup
       attribute :fn, ::Sts::IsoSts::Fn
-      attribute :attrib, ::Sts::NisoSts::Attrib
+      attribute :attrib, ::Sts::IsoSts::Attrib
       attribute :permissions, ::Sts::IsoSts::Permissions
 
       xml do

--- a/spec/iso_sts/iso_sts_element_spec.rb
+++ b/spec/iso_sts/iso_sts_element_spec.rb
@@ -971,7 +971,7 @@ RSpec.describe Sts::IsoSts do
                           id content_type specific_use xml_lang originator
                           label title paragraph list def_list non_normative_note
                           non_normative_example preformat fig graphic
-                          disp_formula disp_quote permissions
+                          disp_formula disp_quote attrib permissions
                         ])
     end
 
@@ -983,7 +983,7 @@ RSpec.describe Sts::IsoSts do
                           paragraph list def_list non_normative_note
                           non_normative_example preformat fig graphic
                           disp_formula disp_quote boxed_text sec term_sec
-                          fn_group ref_list permissions
+                          fn_group ref_list attrib permissions
                         ])
     end
 
@@ -1000,7 +1000,7 @@ RSpec.describe Sts::IsoSts do
         non_normative_note: :NonNormativeNote,
         non_normative_example: :NonNormativeExample, preformat: :Preformat,
         fig: :Fig, graphic: :Graphic, disp_formula: :DispFormula,
-        disp_quote: :DispQuote, permissions: :Permissions
+        disp_quote: :DispQuote, attrib: :Attrib, permissions: :Permissions
       },
       BoxedText: {
         sts_object_id: :ObjectId, paragraph: :Paragraph, list: :List,
@@ -1009,7 +1009,7 @@ RSpec.describe Sts::IsoSts do
         fig: :Fig, graphic: :Graphic, disp_formula: :DispFormula,
         disp_quote: :DispQuote, boxed_text: :BoxedText, sec: :Sec,
         term_sec: :TermSec, fn_group: :FnGroup, ref_list: :RefList,
-        permissions: :Permissions
+        attrib: :Attrib, permissions: :Permissions
       },
     }.each do |klass, children|
       children.each do |attr, child_class|
@@ -1044,6 +1044,61 @@ RSpec.describe Sts::IsoSts do
     it "Sec#boxed_text is IsoSts::BoxedText" do
       expect(described_class::Sec.attributes[:boxed_text].type)
         .to eq(described_class::BoxedText)
+    end
+  end
+
+  # ISOSTS <attrib> is mixed content with many inline children. Modelled from
+  # ISOSTS.xsd with the subset of inline-element children that have IsoSts
+  # classes today; omitted children (inline-supplementary-material,
+  # related-article, related-object, element-citation, overline, roman,
+  # sans-serif, alternatives, private-char, chem-struct, mml:math, target,
+  # tbx:entailedTerm) tracked in TODO.sts-refactor/03-namespace-coupling.md.
+  describe "IsoSts::Attrib is modelled from ISOSTS.xsd" do
+    it "models its configured attribute set" do
+      expect(described_class::Attrib.attributes.keys)
+        .to match_array(%i[
+                          id specific_use xml_lang content email ext_link uri
+                          mixed_citation std bold italic monospace num sc
+                          strike underline inline_graphic inline_formula abbrev
+                          milestone_end milestone_start named_content
+                          styled_content fn xref std_ref sub sup
+                        ])
+    end
+
+    it "Array#attrib is IsoSts::Attrib" do
+      expect(described_class::Array.attributes[:attrib].type)
+        .to eq(described_class::Attrib)
+    end
+
+    it "TableWrapFoot#attrib is IsoSts::Attrib" do
+      expect(described_class::TableWrapFoot.attributes[:attrib].type)
+        .to eq(described_class::Attrib)
+    end
+
+    it "DispQuote#attrib is IsoSts::Attrib (was omitted in PR #48)" do
+      expect(described_class::DispQuote.attributes[:attrib].type)
+        .to eq(described_class::Attrib)
+    end
+
+    it "BoxedText#attrib is IsoSts::Attrib (was omitted in PR #48)" do
+      expect(described_class::BoxedText.attributes[:attrib].type)
+        .to eq(described_class::Attrib)
+    end
+
+    it "round-trips a typical attrib with mixed content" do
+      xml = '<attrib id="attr-1" specific-use="source" xml:lang="en">' \
+            "Adapted from <std><std-ref>ISO 9001</std-ref></std> " \
+            "by <bold>the committee</bold>.</attrib>"
+      parsed = described_class::Attrib.from_xml(xml)
+      expect(parsed.id).to eq("attr-1")
+      expect(parsed.specific_use).to eq("source")
+      expect(parsed.xml_lang).to eq("en")
+      expect(parsed.std.size).to eq(1)
+      expect(parsed.bold.size).to eq(1)
+      expect(parsed.content.join).to include("Adapted from")
+      expect(parsed.content.join).to include("by")
+      expect(described_class::Attrib.to_xml(parsed))
+        .to be_xml_equivalent_to(xml)
     end
   end
 end


### PR DESCRIPTION
## Summary

Models `IsoSts::Attrib` from ISOSTS.xsd and resolves 2 of the 13 remaining IsoSts→NisoSts coupling references (issue #40):

- `IsoSts::Array#attrib` was typed `NisoSts::Attrib`
- `IsoSts::TableWrapFoot#attrib` was typed `NisoSts::Attrib`

**Bonus**: fills the `<attrib>` omission left in `IsoSts::DispQuote` and `IsoSts::BoxedText` from PR #48 — both classes now model `<attrib>` as `IsoSts::Attrib`, matching the ISOSTS schema.

## Schema source

`reference-docs/isosts-v1/xsd/ISOSTS.xsd` defines `<attrib>` as mixed content with 3 attributes (`id`, `specific-use`, `xml:lang`) and 35 inline-element children. This PR models the 25 children that have IsoSts classes today:

`email`, `ext_link`, `uri`, `mixed_citation`, `std`, `bold`, `italic`, `monospace`, `num`, `sc`, `strike`, `underline`, `inline_graphic`, `inline_formula`, `abbrev`, `milestone_end`, `milestone_start`, `named_content`, `styled_content`, `fn`, `xref`, `std_ref`, `sub`, `sup`, plus `content` for mixed text.

Omitted children (`inline-supplementary-material`, `related-article`, `related-object`, `element-citation`, `overline`, `roman`, `sans-serif`, `alternatives`, `private-char`, `chem-struct`, `mml:math`, `target`, `tbx:entailedTerm`) — no IsoSts class for them yet. Tracked in `TODO.sts-refactor/03-namespace-coupling.md`.

## Files

- `lib/sts/iso_sts/attrib.rb` (new) — mixed-content class with 3 attrs + 25 IsoSts children
- `lib/sts/iso_sts.rb` — autoload for `Attrib`
- `lib/sts/iso_sts/array.rb`, `lib/sts/iso_sts/table_wrap_foot.rb` — repoint `:attrib` to `IsoSts::Attrib`
- `lib/sts/iso_sts/disp_quote.rb`, `lib/sts/iso_sts/boxed_text.rb` — add `:attrib` child (PR #48 gap fill)
- `spec/iso_sts/iso_sts_element_spec.rb` — 6 new specs (attribute-set assertion, 4 type assertions, round-trip)
- `TODO.sts-refactor/03-namespace-coupling.md` + `00-overview.md` — updated count to 63→11

## Test plan

- [x] `bundle exec rspec` — 2563 examples, 0 failures (was 2551; +12 net: +6 new Attrib specs, +6 from updated DispQuote/BoxedText child-type assertions)
- [x] `bundle exec rubocop` — clean
- [ ] CI green
